### PR TITLE
Fix blackduck ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: Blackduck detect
           command: |
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-            ci-build digitalasset_ex-bond-issuance master \
+            ci-build digitalasset_contingent-claims fix-blackduck-ci \
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.excluded.detector.types=pip \
             --detect.notices.report=false \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - fix-blackduck-ci
     jobs:
       - daml_test:
           daml_sdk_version: "1.12.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: Blackduck detect
           command: |
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-            ci-build digitalasset_contingent-claims fix-blackduck-ci \
+            ci-build digitalasset_contingent-claims master \
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.excluded.detector.types=pip \
             --detect.notices.report=false \
@@ -109,7 +109,7 @@ workflows:
           filters:
             branches:
               only:
-                - fix-blackduck-ci
+                - master
     jobs:
       - daml_test:
           daml_sdk_version: "1.12.0"


### PR DESCRIPTION
It was pointing to another project (ex-bond-issuance) and uploading the reports there accidentally.