### PR TITLE
Change serialized representation to unroll `And`.

### DIFF
--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -114,29 +114,30 @@ isBearerExecutor = cata \case
 
 -- | Converts a `Serialized.Claim` read from ledger, to a more general `Claim`, for use with `Daml.Control.Recursion`.
 deserialize : Serialized.Claim t a -> Claim Observation t a
-deserialize = ana \case
+deserialize = futu \case
   Serialized.Zero -> ZeroF
   Serialized.One a -> OneF a
-  Serialized.Give c -> GiveF c
-  Serialized.And c c' -> AndF c c'
-  Serialized.Or c c' -> OrF c c'
-  Serialized.Cond k c c' -> CondF k c c'
-  Serialized.Scale k c -> ScaleF k c
-  Serialized.When p c -> WhenF p c
+  Serialized.Give c -> GiveF . Pure $ c
+  Serialized.And (c :: c' :: cs) -> DA.Foldable.foldr (\c f -> AndF (Pure c) (Impure f)) (AndF (Pure c) (Pure c')) cs
+  Serialized.And oneOrNil -> error "deserialize: Malformed `And` (should have at least two elements)"
+  Serialized.Or c c' -> OrF (Pure c) (Pure c')
+  Serialized.Cond k c c' -> CondF k (Pure c) (Pure c')
+  Serialized.Scale k c -> ScaleF k (Pure c)
+  Serialized.When p c -> WhenF p (Pure c)
 --  Serialized.Anytime p c -> AnytimeF p c
 --  Serialized.Until p c -> UntilF p c
 
 -- | Converts a `Claim` into a `Serializable.Claim`, so it can be written to the ledger.
 serialize : Claim Observation t a -> Serialized.Claim t a
-serialize = ana \case
-  Zero -> Serialized.ZeroF
-  One a -> Serialized.OneF a
-  Give c -> Serialized.GiveF c
-  And c c' -> Serialized.AndF c c'
-  Or c c' -> Serialized.OrF c c'
-  Cond k c c' -> Serialized.CondF k c c'
-  Scale k c -> Serialized.ScaleF k c
-  When p c -> Serialized.WhenF p c
+serialize = cata \case
+  ZeroF -> Serialized.Zero
+  OneF a -> Serialized.One a
+  GiveF c -> Serialized.Give c
+  AndF c c' -> Serialized.And [c, c']
+  OrF c c' -> Serialized.Or c c'
+  CondF k c c' -> Serialized.Cond k c c'
+  ScaleF k c -> Serialized.Scale k c
+  WhenF p c -> Serialized.When p c
 --  Anytime p c -> Serialized.AnytimeF p c
 --  Until p c -> Serialized.UntilF p c
 

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -129,15 +129,16 @@ deserialize = futu \case
 
 -- | Converts a `Claim` into a `Serializable.Claim`, so it can be written to the ledger.
 serialize : Claim Observation t a -> Serialized.Claim t a
-serialize = cata \case
+serialize = histo \case
   ZeroF -> Serialized.Zero
   OneF a -> Serialized.One a
-  GiveF c -> Serialized.Give c
-  AndF c c' -> Serialized.And [c, c']
-  OrF c c' -> Serialized.Or c c'
-  CondF k c c' -> Serialized.Cond k c c'
-  ScaleF k c -> Serialized.Scale k c
-  WhenF p c -> Serialized.When p c
+  GiveF c -> Serialized.Give c.attribute
+  AndF c (Cofree (Serialized.And cs) _) -> Serialized.And $ c.attribute :: cs
+  AndF c c' -> Serialized.And [c.attribute, c'.attribute]
+  OrF c c' -> Serialized.Or c.attribute c'.attribute
+  CondF k c c' -> Serialized.Cond k c.attribute c'.attribute
+  ScaleF k c -> Serialized.Scale k c.attribute
+  WhenF p c -> Serialized.When p c.attribute
 --  Anytime p c -> Serialized.AnytimeF p c
 --  Until p c -> Serialized.UntilF p c
 

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -117,6 +117,7 @@ deserialize : Serialized.Claim t a -> Claim Observation t a
 deserialize = ana deserialize' 
 
 -- | F-algebra for `deserialize`; it can be composed in unfolds.
+deserialize' : Serialized.Claim t a -> ClaimF Observation t a (Serialized.Claim t a)
 deserialize' Serialized.Zero = ZeroF
 deserialize' (Serialized.One a) = OneF a
 deserialize' (Serialized.Give c) = GiveF c
@@ -135,6 +136,7 @@ serialize : Claim Observation t a -> Serialized.Claim t a
 serialize = histo serialize'
 
 -- | F-coalgebra for `serialize`; it can be composed with other folds.
+serialize' : ClaimF Observation t a (Cofree (ClaimF Observation t a) (Serialized.Claim t a)) -> Serialized.Claim t a 
 serialize' ZeroF = Serialized.Zero
 serialize' (OneF a) = Serialized.One a
 serialize' (GiveF c) = Serialized.Give c.attribute

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -114,34 +114,38 @@ isBearerExecutor = cata \case
 
 -- | Converts a `Serialized.Claim` read from ledger, to a more general `Claim`, for use with `Daml.Control.Recursion`.
 deserialize : Serialized.Claim t a -> Claim Observation t a
-deserialize = futu \case
-  Serialized.Zero -> ZeroF
-  Serialized.One a -> OneF a
-  Serialized.Give c -> GiveF . Pure $ c
-  Serialized.And (c :: c' :: cs) -> DA.Foldable.foldr (\c f -> AndF (Pure c) (Impure f)) (AndF (Pure c) (Pure c')) cs
-  Serialized.And oneOrNil -> error "deserialize: Malformed `And` (should have at least two elements)"
-  Serialized.Or c c' -> OrF (Pure c) (Pure c')
-  Serialized.Cond k c c' -> CondF k (Pure c) (Pure c')
-  Serialized.Scale k c -> ScaleF k (Pure c)
-  Serialized.When p c -> WhenF p (Pure c)
---  Serialized.Anytime p c -> AnytimeF p c
---  Serialized.Until p c -> UntilF p c
+deserialize = ana deserialize' 
+
+-- | F-algebra for `deserialize`; it can be composed in unfolds.
+deserialize' Serialized.Zero = ZeroF
+deserialize' (Serialized.One a) = OneF a
+deserialize' (Serialized.Give c) = GiveF c
+deserialize' (Serialized.And [c]) = deserialize'  c
+deserialize' (Serialized.And (c :: cs)) = AndF c (Serialized.And cs)
+deserialize' (Serialized.And []) = error "deserialize: Malformed `And` (should have at least two elements)"
+deserialize' (Serialized.Or c c') = OrF c c'
+deserialize' (Serialized.Cond k c c') = CondF k c c'
+deserialize' (Serialized.Scale k c) = ScaleF k c
+deserialize' (Serialized.When p c) = WhenF p c
+--  Serialized.Anytime p c = AnytimeF p c
+--  Serialized.Until p c = UntilF p c
 
 -- | Converts a `Claim` into a `Serializable.Claim`, so it can be written to the ledger.
 serialize : Claim Observation t a -> Serialized.Claim t a
-serialize = histo \case
-  ZeroF -> Serialized.Zero
-  OneF a -> Serialized.One a
-  GiveF c -> Serialized.Give c.attribute
-  AndF c (Cofree (Serialized.And cs) _) -> Serialized.And $ c.attribute :: cs
-  AndF c c' -> Serialized.And [c.attribute, c'.attribute]
-  OrF c c' -> Serialized.Or c.attribute c'.attribute
-  CondF k c c' -> Serialized.Cond k c.attribute c'.attribute
-  ScaleF k c -> Serialized.Scale k c.attribute
-  WhenF p c -> Serialized.When p c.attribute
+serialize = histo serialize'
+
+-- | F-coalgebra for `serialize`; it can be composed with other folds.
+serialize' ZeroF = Serialized.Zero
+serialize' (OneF a) = Serialized.One a
+serialize' (GiveF c) = Serialized.Give c.attribute
+serialize' (AndF c (Cofree (Serialized.And cs) _) ) = Serialized.And $ c.attribute :: cs
+serialize' (AndF c c') = Serialized.And [c.attribute, c'.attribute]
+serialize' (OrF c c') = Serialized.Or c.attribute c'.attribute
+serialize' (CondF k c c') = Serialized.Cond k c.attribute c'.attribute
+serialize' (ScaleF k c) = Serialized.Scale k c.attribute
+serialize' (WhenF p c) = Serialized.When p c.attribute
 --  Anytime p c -> Serialized.AnytimeF p c
 --  Until p c -> Serialized.UntilF p c
-
 
 -- | Unfixed version of `Claim`, for use with `Daml.Control.Recursion`.
 data ClaimF f t a x

--- a/daml/ContingentClaims/Claim/Serializable.daml
+++ b/daml/ContingentClaims/Claim/Serializable.daml
@@ -22,7 +22,8 @@ data Claim t a
   | Give (Claim t a)
       -- ^ The obligations of the bearer and issuer are revesed.
   | And with claims : [Claim t a]
-      -- ^ Used to combine multiple rights together.
+      -- ^ Used to combine multiple rights together. 
+      --   __Note__ This serialized version flattens right-associative `And`s to mitigate language recursion limits.
   | Or with lhs: Claim t a, rhs: Claim t a 
       -- ^ Gives the bearer the right to choose between two claims.
   | Cond with predicate: Observation t Bool, success: Claim t a, failure: Claim t a 

--- a/daml/ContingentClaims/Claim/Serializable.daml
+++ b/daml/ContingentClaims/Claim/Serializable.daml
@@ -21,7 +21,7 @@ data Claim t a
       -- ^ The bearer acquires one unit of `a` *immediately*.
   | Give (Claim t a)
       -- ^ The obligations of the bearer and issuer are revesed.
-  | And with lhs: Claim t a, rhs: Claim t a 
+  | And with claims : [Claim t a]
       -- ^ Used to combine multiple rights together.
   | Or with lhs: Claim t a, rhs: Claim t a 
       -- ^ Gives the bearer the right to choose between two claims.
@@ -41,7 +41,7 @@ data ClaimF t a x
   = ZeroF
   | OneF a
   | GiveF x
-  | AndF with lhs: x, rhs: x
+  | AndF with claims: [x]
   | OrF with lhs: x, rhs: x
   | CondF with predicate: (Observation t Bool), success: x, failure: x
   | ScaleF with k: (Observation t Decimal), claim: x
@@ -54,7 +54,7 @@ instance Recursive (Claim t a) (ClaimF t a) where
   project Zero = ZeroF
   project (One a) = OneF a
   project (Give c) = GiveF c
-  project (And c c') = (AndF c c')
+  project (And cs) = (AndF cs)
   project (Or c c') = (OrF c c')
   project (Cond a c c') = CondF a c c'
   project (Scale k a) = ScaleF k a
@@ -66,7 +66,7 @@ instance Corecursive (Claim t a) (ClaimF t a) where
   embed ZeroF = Zero
   embed (OneF a) = One a
   embed (GiveF c) = Give c
-  embed (AndF c c') = (And c c')
+  embed (AndF cs) = (And cs)
   embed (OrF c c') = (Or c c')
   embed (CondF a c c') = Cond a c c'
   embed (ScaleF k a) = Scale k a

--- a/test/daml/Test/Initialization.daml
+++ b/test/daml/Test/Initialization.daml
@@ -21,6 +21,6 @@ createContracts = script do
   -- vod_l  <- submit buyer . createCmd $ Quote "GB00BH4HKS39" (date 2021 Feb 8) 127.36 buyer
   let mkContract = submit buyer . createCmd . FinancialContract buyer buyer . serialize
   mkContract $ zcb (date 2021 Mar 3) 3400.0 (Left USD)
-  mkContract $ fixed 100.0 4.0 (Left GBP) (unrollDates 2021 2025 [Jan, Aug] 5) -- large # of coupons causes API to crash
+  mkContract $ fixed 100.0 4.0 (Left GBP) (unrollDates 2021 2025 [Jan, Aug] 5)
   mkContract $ european (date 2021 Feb 8) (one . Right $ "GB00BH4HKS39")
 

--- a/test/daml/Test/Serialization.daml
+++ b/test/daml/Test/Serialization.daml
@@ -1,0 +1,32 @@
+--
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+module Test.Serialization where
+
+import Daml.Script
+import ContingentClaims.Claim
+import ContingentClaims.Claim.Serializable qualified as S
+import ContingentClaims.Claim.Serializable ()
+import ContingentClaims.FinancialClaim
+import DA.Assert
+import DA.Date (Month(..))
+import ContingentClaims.Observation (Observation)
+
+deriving instance Show (Claim Observation Date Text)
+deriving instance Eq (Claim Observation Date Text)
+
+testSerialization = script do
+  let fixingDates = unrollDates 2020 2025 [Jan] 15
+      bond : Claim Observation Date Text = fixed 100.0 3.0 "USD" fixingDates
+      zero : Claim Observation Date Text = Zero
+
+  -- identity
+  (deserialize . serialize $ bond) === bond
+
+  -- base case
+  serialize (zero `And` zero) === S.And [S.Zero, S.Zero]
+
+  -- inductive case
+  serialize (zero `And` (zero `And` zero)) === S.And [S.Zero, S.Zero, S.Zero]


### PR DESCRIPTION
That is, a right-recursive `And` structure will become a list of `Claim` in a
single `Serializable.And [Claim]`. This makes trees much more 'shallow' and resolves #7.