### PR TITLE
Remove smart constructors

### DIFF
--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -47,28 +47,6 @@ data Claim f t a
 --  | Anytime with predicate: f t Bool, claim: Claim f t a
 --  | Until with predicate: f t Bool, claim: Claim f t a
 
--- FIXME: why doesn't this work? Consider removing these, as we use mostly higher-level combinators.
--- zero : Claim f t a
--- zero = Zero
-
-one ccy = One ccy
-
-give x = Give x
-
-and c1 c2 = And c1 c2
-
-or c1 c2 = Or c1 c2
-
-cond p c1 c2 = Cond p c1 c2
-
-scale k c1 = Scale k c1
-
-when o c1 = When o c1
-
--- anytime o c1 = Anytime o c1
-
--- until o c1 = Until o c1
-
 -- | Return the upper time bound of the obligation; `None` if it cannot be determined.
 -- This is called `horizon` in the original paper.
 expiry : forall t a . Ord t => Claim Observation t a -> Optional t

--- a/daml/ContingentClaims/FinancialClaim.daml
+++ b/daml/ContingentClaims/FinancialClaim.daml
@@ -27,7 +27,7 @@ at t = O.time O.== (O.pure t)
 
 -- | Forward agreement. Discounted by (potentially stochastic) interest rate `r`.
 forward : Observable f t => t -> f t Decimal -> Claim f t a -> Claim f t a
-forward maturity r payoff = when (at maturity) $ scale r payoff
+forward maturity r payoff = When (at maturity) $ Scale r payoff
 
 -- | Forward rate agreement. 
 fra : Observable f t => t -> t -> f t Decimal -> f t Decimal -> Claim f t a -> Claim f t a
@@ -35,14 +35,14 @@ fra t₁ t₂ r₀ r₁ = forward t₁ r₀ . forward t₂ r₁
 
 -- | Zero Coupon Bond.
 zcb : Observable f t => t -> Decimal -> ccy -> Claim f t ccy
-zcb maturity principal ccy = forward maturity (O.pure principal) (one ccy)
+zcb maturity principal ccy = forward maturity (O.pure principal) (One ccy)
 
 -- | A floating rate bond. The first two arguments are `Observable`s.
 floating : Observable f t => f t Decimal -> f t Decimal -> ccy -> [t] -> Claim f t ccy
 floating principal coupon asset = apo \case
-     [maturity] -> Left (forward maturity coupon (one asset)) `AndF` 
-                   Left (forward maturity principal (one asset))
-     (t :: ts) -> Left (forward t coupon (one asset)) `AndF` Right ts
+     [maturity] -> Left (forward maturity coupon (One asset)) `AndF` 
+                   Left (forward maturity principal (One asset))
+     (t :: ts) -> Left (forward t coupon (One asset)) `AndF` Right ts
      [] -> ZeroF
 
 -- | A (fixed rate) coupon paying bond.
@@ -56,7 +56,7 @@ fixed principal coupon = floating (O.pure principal) (O.pure coupon)
 european
   : forall f t a . (TimeF f t, PointF f t t, InequalityF f t t)
   => t -> Claim f t a -> Claim f t a
-european t u = when (at t) (u `or` Zero)
+european t u = When (at t) (u `Or` Zero)
 
 -- | Bermudan option on the passed claim.
 bermudan
@@ -72,7 +72,7 @@ bermudan u = apo \case
 -- fixedUsdVsFloatingEur = fixed 100.0 0.02 "USD" `swap` floating (observe "USDEUR" * pure 100.0) (observe "EUR1M") "EUR"
 -- ```
 swap : forall f t a . ([t] -> Claim f t a) -> ([t] -> Claim f t a) -> [t] -> Claim f t a
-swap receive pay ts = receive ts `and` give (pay ts)
+swap receive pay ts = receive ts `And` Give (pay ts)
 
 {-
 between

--- a/test/daml/Test/Initialization.daml
+++ b/test/daml/Test/Initialization.daml
@@ -22,5 +22,5 @@ createContracts = script do
   let mkContract = submit buyer . createCmd . FinancialContract buyer buyer . serialize
   mkContract $ zcb (date 2021 Mar 3) 3400.0 (Left USD)
   mkContract $ fixed 100.0 4.0 (Left GBP) (unrollDates 2021 2025 [Jan, Aug] 5)
-  mkContract $ european (date 2021 Feb 8) (one . Right $ "GB00BH4HKS39")
+  mkContract $ european (date 2021 Feb 8) (One . Right $ "GB00BH4HKS39")
 

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -34,7 +34,7 @@ deriving instance Eq (F (Cofree F Int))
 
 lifecycling = script do
   let spot _ _ = pure (0.0 : Decimal)
-      cashflow = when (at $ date 2020 Jan 01) (one a)
+      cashflow = When (at $ date 2020 Jan 01) (One a)
   Lifecycle.Result{remaining, pending} <-
     Lifecycle.lifecycle spot const cashflow (date 2020 Jan 01)
   remaining === Zero
@@ -67,7 +67,7 @@ lifecycling = script do
   remaining === Zero
   pending === pure (43.4 - 42.0, a)
 
-  let weirdNote : C = when (at $ date 2021 Mar 9) $ one a `or` one b
+  let weirdNote : C = When (at $ date 2021 Mar 9) $ One a `Or` One b
   Lifecycle.Result{remaining, pending} <-
      Lifecycle.lifecycle spot chooseLeft weirdNote (date 2021 Mar 9)
   remaining === Zero


### PR DESCRIPTION
I'd like to remove the lower-case constructors that double for the `Claim` ADT constructors. I don't see any added benefits of having them, and only disadvantages:

- `zero` doesn't compile for some strange reason, so you'll always need to do an upper-case `Zero` anyway.
- `and` and `or` clash with prelude
- Having both these and the constructors means you can have mixed upper-case and lower-case, which I think is confusing.

These were never meant to be visible at the surface-level API; rather, they should be lower-level building blocks for more concrete instruments, like those in `FinancialClaim`.