### PR TITLE
Fixes #10, pruning on lifecycle

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -17,9 +17,10 @@ import ContingentClaims.Observation (Observation, eval)
 import ContingentClaims.Util (apoCataM)
 import Daml.Control.Recursion (apo, project, embed)
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
-import Daml.Control.Monad.Reader (ReaderT(..), runReaderT)
+import Daml.Control.Monad.State (StateT(..), evalStateT)
 import Daml.Control.Monad.MonadReader (MonadReader(..))
 import Daml.Control.Monad.MonadWriter (MonadWriter(..))
+import Daml.Control.Monad.MonadState (MonadState(..), modify)
 import Daml.Control.Monad.Trans
 import Daml.Control.Arrow (Kleisli(..))
 import Prelude hiding (sequence, mapA)
@@ -50,18 +51,23 @@ lifecycle : (Eq a, CanAbort m)
 lifecycle spot choose
   = runKleisli
   . fmap (uncurry Result)
-  . flip runReaderT 1.0
+  . flip evalStateT 1.0
   . runWriterT
   . apoCataM (pruneZeros') (lifecycle' spot choose) -- (fmap (pruneZeros' . project) . (lifecycle' spot choose))
 
-type Seed m a = WriterT [(Decimal, a)] (ReaderT Decimal (Kleisli m Date)) (F a (Either (C a) (C a)))
+type Seed m a = WriterT [(Decimal, a)] (StateT Decimal (Kleisli m Date)) (F a (Either (C a) (C a)))
 
 -- TODO: these three should probably go in their respective modules
 
 instance (Monoid w, CanAbort m) => CanAbort (WriterT w m) where
   abort = lift . abort
 
+{-
 instance CanAbort m => CanAbort (ReaderT s m) where
+  abort = lift . abort
+-}
+
+instance CanAbort m => CanAbort (StateT s m) where
   abort = lift . abort
 
 instance CanAbort m => CanAbort (Kleisli m a) where -- because of the order of parameters it's not possible to write a MonadTrans instance for Kleisli.
@@ -74,16 +80,19 @@ lifecycle' : (Eq a, Monad m, CanAbort m)
 
 lifecycle' _ _ Zero = pure ZeroF
 lifecycle' _ _ (One id) = do
-  qty <- ask
+  qty <- get
   tell [(qty, id)]
-  pure ZeroF 
-lifecycle' _ _ (Give c) = local negate (pure . GiveF . Right $ c)
+  pure ZeroF -- replace lifecycled node with zero, to avoid double-spend.
+lifecycle' _ _ (Give c) = do
+  modify negate 
+  pure $ GiveF (Right c)
 lifecycle' spot _ (When obs c) = do
   predicate <- lift . lift $ eval spot obs
-  pure if predicate then Right <$> WhenF obs c else Left <$> WhenF obs c
+  pure $ if predicate then WhenF obs (Right c) else WhenF obs (Left c)
 lifecycle' spot _ (Scale obs c) = do
   k <- lift . lift $ eval spot obs
-  local (* k) (pure . ScaleF obs $ Right c)
+  modify (* k) 
+  pure $ ScaleF obs (Right c)
 lifecycle' _ choose (Or c c') =
   let chosen = choose c c'
   in if | chosen == c -> pure $ Right <$> project c
@@ -92,7 +101,7 @@ lifecycle' _ choose (Or c c') =
 lifecycle' _ _ (And c c') = pure $ AndF (Right c) (Right c')
 lifecycle' spot _ (Cond obs c c') = do
   predicate <- lift . lift $ eval spot obs
-  pure if predicate then Left <$> project c else Left <$> project c'
+  pure if predicate then Right <$> project c else Right <$> project c'
 
 -- | Prunes sub-trees which are `Zero` a.s.
 pruneZeros' : F a (C a) -> C a

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -14,7 +14,7 @@ module ContingentClaims.Lifecycle (
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation, eval)
-import Daml.Control.Recursion (para)
+import Daml.Control.Recursion (para, project, embed)
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
 import Daml.Control.Monad.Reader (ReaderT(..), runReaderT)
 import Daml.Control.Monad.MonadReader (MonadReader(..))
@@ -42,16 +42,16 @@ data Result a = Result with
 -- 3. A set of `Claim`s.
 -- 4. A function which, given a date, lifecycles the third argument.
 lifecycle : (Eq a, CanAbort m)
-  => (Text -> Date -> m Decimal) 
-  -> (C a -> C a -> C a) 
-  -> C a 
-  -> Date -> m (Result a) 
+  => (Text -> Date -> m Decimal)
+  -> (C a -> C a -> C a)
+  -> C a
+  -> Date -> m (Result a)
 lifecycle spot choose
   = runKleisli
   . fmap (uncurry Result)
   . flip runReaderT 1.0
   . runWriterT
-  . para (lifecycle' spot choose)
+  . para (fmap (pruneZeros' . project) . (lifecycle' spot choose))
 
 type Seed m a = WriterT [(Decimal, a)] (ReaderT Decimal (Kleisli m Date)) (C a)
 
@@ -78,20 +78,26 @@ lifecycle' _ _ (OneF id) = do
   pure $ One id
 lifecycle' _ _ (GiveF (_, m)) = local negate m
 lifecycle' spot _ (WhenF obs (c, m)) = do
-  wasLifecycled <- lift . lift $ eval spot obs
-  if wasLifecycled then m $> Zero else pure $ When obs c
+  predicate <- lift . lift $ eval spot obs
+  if predicate then m $> Zero else pure $ When obs c
 lifecycle' spot _ (ScaleF obs (_, m)) = do
   k <- lift . lift $ eval spot obs
-  local (* k) m
+  Scale obs <$> local (* k) m
 lifecycle' _ choose (OrF (c, m) (c', m')) = do
   let chosen = choose c c'
   if | chosen == c -> m
      | chosen == c' -> m'
      | otherwise -> abort "lifecycle: Invalid branch election"
-lifecycle' _ _ (AndF (_, m) (_, m')) = reduceZero <$> m <*> m' where
-   reduceZero Zero c' = c'
-   reduceZero c Zero = c
-   reduceZero c c' = And c c'
+lifecycle' _ _ (AndF (_, m) (_, m')) = And <$> m <*> m'
 lifecycle' spot _ (CondF obs (_, m) (_, m')) = do
   predicate <- lift . lift $ eval spot obs
   if predicate then m else m'
+
+-- | Prunes sub-trees which are `Zero` a.s.
+pruneZeros' : F a (C a) -> C a
+pruneZeros' (ScaleF _ Zero) = Zero
+pruneZeros' (GiveF Zero) = Zero
+pruneZeros' (AndF Zero Zero) = Zero
+pruneZeros' (AndF Zero c) = c
+pruneZeros' (AndF c Zero) = c
+pruneZeros' other = embed other

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -15,16 +15,14 @@ module ContingentClaims.Lifecycle (
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation, eval)
 import ContingentClaims.Util (apoCataM)
-import Daml.Control.Recursion (apo, project, embed)
+import Daml.Control.Recursion (embed)
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
 import Daml.Control.Monad.State (StateT(..), evalStateT)
-import Daml.Control.Monad.MonadReader (MonadReader(..))
 import Daml.Control.Monad.MonadWriter (MonadWriter(..))
 import Daml.Control.Monad.MonadState (MonadState(..), modify)
 import Daml.Control.Monad.Trans
 import Daml.Control.Arrow (Kleisli(..))
 import Prelude hiding (sequence, mapA)
-import DA.Functor (($>),(<&>))
 
 type C a = Claim Observation Date a
 type F a = ClaimF Observation Date a
@@ -93,15 +91,15 @@ lifecycle' spot _ (Scale obs c) = do
   k <- lift . lift $ eval spot obs
   modify (* k) 
   pure $ ScaleF obs (Right c)
-lifecycle' _ choose (Or c c') =
+lifecycle' spot choose (Or c c') = do
   let chosen = choose c c'
-  in if | chosen == c -> pure $ Right <$> project c
-        | chosen == c' -> pure $ Right <$> project c'
-        | otherwise -> abort "lifecycle: Invalid branch election"
+  if | chosen == c -> lifecycle' spot choose c --TODO: should we abort with nested choices?
+     | chosen == c' -> lifecycle' spot choose c'
+     | otherwise -> abort "lifecycle: Invalid branch election"
 lifecycle' _ _ (And c c') = pure $ AndF (Right c) (Right c')
-lifecycle' spot _ (Cond obs c c') = do
+lifecycle' spot choose (Cond obs c c') = do
   predicate <- lift . lift $ eval spot obs
-  pure if predicate then Right <$> project c else Right <$> project c'
+  if predicate then lifecycle' spot choose c else lifecycle' spot choose c'
 
 -- | Prunes sub-trees which are `Zero` a.s.
 pruneZeros' : F a (C a) -> C a

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -51,25 +51,9 @@ lifecycle spot choose
   . fmap (uncurry Result)
   . flip evalStateT 1.0
   . runWriterT
-  . apoCataM (pruneZeros') (lifecycle' spot choose) -- (fmap (pruneZeros' . project) . (lifecycle' spot choose))
+  . apoCataM (pruneZeros') (lifecycle' spot choose)
 
 type Seed m a = WriterT [(Decimal, a)] (StateT Decimal (Kleisli m Date)) (F a (Either (C a) (C a)))
-
--- TODO: these three should probably go in their respective modules
-
-instance (Monoid w, CanAbort m) => CanAbort (WriterT w m) where
-  abort = lift . abort
-
-{-
-instance CanAbort m => CanAbort (ReaderT s m) where
-  abort = lift . abort
--}
-
-instance CanAbort m => CanAbort (StateT s m) where
-  abort = lift . abort
-
-instance CanAbort m => CanAbort (Kleisli m a) where -- because of the order of parameters it's not possible to write a MonadTrans instance for Kleisli.
-  abort = Kleisli . const . abort
 
 lifecycle' : (Eq a, Monad m, CanAbort m)
   => (Text -> Date -> m Decimal)

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -14,7 +14,8 @@ module ContingentClaims.Lifecycle (
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation, eval)
-import Daml.Control.Recursion (para, project, embed)
+import ContingentClaims.Util (apoCataM)
+import Daml.Control.Recursion (apo, project, embed)
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
 import Daml.Control.Monad.Reader (ReaderT(..), runReaderT)
 import Daml.Control.Monad.MonadReader (MonadReader(..))
@@ -22,7 +23,7 @@ import Daml.Control.Monad.MonadWriter (MonadWriter(..))
 import Daml.Control.Monad.Trans
 import Daml.Control.Arrow (Kleisli(..))
 import Prelude hiding (sequence, mapA)
-import DA.Functor (($>))
+import DA.Functor (($>),(<&>))
 
 type C a = Claim Observation Date a
 type F a = ClaimF Observation Date a
@@ -51,9 +52,9 @@ lifecycle spot choose
   . fmap (uncurry Result)
   . flip runReaderT 1.0
   . runWriterT
-  . para (fmap (pruneZeros' . project) . (lifecycle' spot choose))
+  . apoCataM (pruneZeros') (lifecycle' spot choose) -- (fmap (pruneZeros' . project) . (lifecycle' spot choose))
 
-type Seed m a = WriterT [(Decimal, a)] (ReaderT Decimal (Kleisli m Date)) (C a)
+type Seed m a = WriterT [(Decimal, a)] (ReaderT Decimal (Kleisli m Date)) (F a (Either (C a) (C a)))
 
 -- TODO: these three should probably go in their respective modules
 
@@ -69,29 +70,29 @@ instance CanAbort m => CanAbort (Kleisli m a) where -- because of the order of p
 lifecycle' : (Eq a, Monad m, CanAbort m)
   => (Text -> Date -> m Decimal)
   -> (C a -> C a -> C a)
-  -> F a (C a, Seed m a) -> Seed m a
+  -> C a -> Seed m a
 
-lifecycle' _ _ ZeroF = pure Zero
-lifecycle' _ _ (OneF id) = do
+lifecycle' _ _ Zero = pure ZeroF
+lifecycle' _ _ (One id) = do
   qty <- ask
   tell [(qty, id)]
-  pure $ One id
-lifecycle' _ _ (GiveF (_, m)) = local negate m
-lifecycle' spot _ (WhenF obs (c, m)) = do
+  pure ZeroF 
+lifecycle' _ _ (Give c) = local negate (pure . GiveF . Right $ c)
+lifecycle' spot _ (When obs c) = do
   predicate <- lift . lift $ eval spot obs
-  if predicate then m $> Zero else pure $ When obs c
-lifecycle' spot _ (ScaleF obs (_, m)) = do
+  pure if predicate then Right <$> WhenF obs c else Left <$> WhenF obs c
+lifecycle' spot _ (Scale obs c) = do
   k <- lift . lift $ eval spot obs
-  Scale obs <$> local (* k) m
-lifecycle' _ choose (OrF (c, m) (c', m')) = do
+  local (* k) (pure . ScaleF obs $ Right c)
+lifecycle' _ choose (Or c c') =
   let chosen = choose c c'
-  if | chosen == c -> m
-     | chosen == c' -> m'
-     | otherwise -> abort "lifecycle: Invalid branch election"
-lifecycle' _ _ (AndF (_, m) (_, m')) = And <$> m <*> m'
-lifecycle' spot _ (CondF obs (_, m) (_, m')) = do
+  in if | chosen == c -> pure $ Right <$> project c
+        | chosen == c' -> pure $ Right <$> project c'
+        | otherwise -> abort "lifecycle: Invalid branch election"
+lifecycle' _ _ (And c c') = pure $ AndF (Right c) (Right c')
+lifecycle' spot _ (Cond obs c c') = do
   predicate <- lift . lift $ eval spot obs
-  if predicate then m else m'
+  pure if predicate then Left <$> project c else Left <$> project c'
 
 -- | Prunes sub-trees which are `Zero` a.s.
 pruneZeros' : F a (C a) -> C a
@@ -100,4 +101,5 @@ pruneZeros' (GiveF Zero) = Zero
 pruneZeros' (AndF Zero Zero) = Zero
 pruneZeros' (AndF Zero c) = c
 pruneZeros' (AndF c Zero) = c
+pruneZeros' (WhenF _ Zero) = Zero
 pruneZeros' other = embed other

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -14,8 +14,7 @@ module ContingentClaims.Lifecycle (
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation, eval)
-import ContingentClaims.Util (apoCataM)
-import Daml.Control.Recursion (embed)
+import ContingentClaims.Util (apoCataM, pruneZeros')
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
 import Daml.Control.Monad.State (StateT(..), evalStateT)
 import Daml.Control.Monad.MonadWriter (MonadWriter(..))
@@ -84,13 +83,3 @@ lifecycle' _ _ (And c c') = pure $ AndF (Right c) (Right c')
 lifecycle' spot choose (Cond obs c c') = do
   predicate <- lift . lift $ eval spot obs
   if predicate then lifecycle' spot choose c else lifecycle' spot choose c'
-
--- | Prunes sub-trees which are `Zero` a.s.
-pruneZeros' : F a (C a) -> C a
-pruneZeros' (ScaleF _ Zero) = Zero
-pruneZeros' (GiveF Zero) = Zero
-pruneZeros' (AndF Zero Zero) = Zero
-pruneZeros' (AndF Zero c) = c
-pruneZeros' (AndF c Zero) = c
-pruneZeros' (WhenF _ Zero) = Zero
-pruneZeros' other = embed other

--- a/daml/ContingentClaims/Util.daml
+++ b/daml/ContingentClaims/Util.daml
@@ -19,6 +19,8 @@ module ContingentClaims.Util (
   , subTreeSize'
   , fixings
   , fixings'
+  , pruneZeros
+  , pruneZeros'
 ) where
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
@@ -99,3 +101,17 @@ fixings = cata fixings'
 fixings' : ClaimF Observation Date a [Date] -> [Date]
 fixings' (WhenF p ts) = O.fixings p ++ ts
 fixings' claim = fold claim
+
+pruneZeros : Claim f t a -> Claim f t a
+pruneZeros = cata pruneZeros'
+
+-- | Prunes sub-trees which are `Zero` a.s.
+pruneZeros' : ClaimF f t a (Claim f t a) -> Claim f t a
+pruneZeros' (ScaleF _ Zero) = Zero
+pruneZeros' (GiveF Zero) = Zero
+pruneZeros' (AndF Zero c) = c
+pruneZeros' (AndF c Zero) = c
+pruneZeros' (WhenF _ Zero) = Zero
+pruneZeros' (CondF _ Zero Zero) = Zero
+pruneZeros' (OrF Zero Zero) = Zero
+pruneZeros' other = embed other

--- a/daml/ContingentClaims/Util.daml
+++ b/daml/ContingentClaims/Util.daml
@@ -11,6 +11,8 @@ module ContingentClaims.Util (
   , cataM
   , paraM
   , anaM
+  , apoM
+  , apoCataM
   , funzip
   , synthesize
   , inherit
@@ -23,20 +25,34 @@ import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation)
 import ContingentClaims.Observation qualified as O
 import DA.Foldable (Foldable, sum, fold)
-import Daml.Control.Arrow ((&&&), (>>>), (<<<), Kleisli(..))
+import Daml.Control.Arrow ((&&&), (|||), (>>>), (<<<), Kleisli(..))
 import Daml.Control.Recursion
-import Prelude hiding (sum, sequence)
-import DA.Traversable (Traversable, sequence)
+import Prelude hiding (sum, sequence, mapA)
+import DA.Traversable (Traversable, sequence, mapA)
 
 -- The morphisms ending in 'M' are monadic variants, allowing to interleave e.g. `Update` or `Script`.
+-- `cataM` After Tim Williams' talk, https://www.youtube.com/watch?v=Zw9KeP3OzpU.
+
+-- TODO: the two folds can probably be simplified with Traverse.mapA too.
 cataM : (Monad m, Traversable f, Recursive b f) => (f a -> m a) -> b -> m a
 cataM f b = (project >>> fmap (cataM f) >>> (>>= f) . sequence) b
 
 paraM : (Monad m, Traversable f, Recursive b f) => (f (b, a) -> m a) -> b -> m a
 paraM f b = (project >>> fmap (runKleisli $ Kleisli pure &&& Kleisli (paraM f)) >>> (>>= f) . sequence) b
 
+-- FIXME : I think the algebra should be a -> m (f a)
 anaM : (Monad m, Traversable f, Corecursive b f) => (a -> f (m a)) -> a -> m b
-anaM f a = (fmap embed <<< sequence <<< fmap (>>= anaM f) <<< f) a
+anaM f a = (fmap embed <<< mapA (>>= anaM f) <<< f) a
+
+apoM : (Monad m, Traversable f, Corecursive b f) => (a -> m (f (Either b a))) -> a -> m b
+apoM f a = (fmap embed <<< (>>= (mapA (pure ||| apoM f))) <<< f) a
+
+-- | Specialised lazy re-fold, used by `lifecycle`.
+apoCataM : (Monad m, Traversable f, Corecursive b f) => (f b -> b) -> (a -> m (f (Either b a))) -> a -> m b
+apoCataM g f a = _apoCataM g f a 
+
+-- | HIDE
+_apoCataM g f a = (fmap g <<< (>>= (mapA (pure ||| apoCataM g f))) <<< f) a
 
 -- Functor unzip
 funzip : Functor f => f (a, b) -> (f a, f b)

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -42,13 +42,19 @@ lifecycling = script do
 
   let nothing : C = Scale (O.pure 1.0) Zero
   Lifecycle.Result{remaining, pending} <-
-    Lifecycle.lifecycle spot const nothing (date 2020 Jan 01)
+    Lifecycle.lifecycle spot const nothing (date 2020 Jan 02)
   remaining === Zero
   pending === mempty
 
-  let fwd = (When (at $ date 2020 Jan 01) $ Give (One a))
+  let something : C = Scale (O.pure 3.0) (One a)
   Lifecycle.Result{remaining, pending} <-
-    Lifecycle.lifecycle spot const fwd (date 2020 Jan 01)
+    Lifecycle.lifecycle spot const something (date 2020 Jan 02)
+  remaining === Zero
+  pending === pure (3.0, a)
+
+  let fwd = (When (at $ date 2020 Jan 03) $ Give (One a))
+  Lifecycle.Result{remaining, pending} <-
+    Lifecycle.lifecycle spot const fwd (date 2020 Jan 03)
   remaining === Zero
   pending === pure (- 1.0, a)
 
@@ -67,19 +73,19 @@ lifecycling = script do
   remaining === Zero
   pending === pure (43.4 - 42.0, a)
 
-  let weirdNote : C = When (at $ date 2021 Mar 9) $ One a `Or` One b
+  let weirdNote : C = When (at $ date 2021 Mar 10) $ One a `Or` One b
   Lifecycle.Result{remaining, pending} <-
-     Lifecycle.lifecycle spot chooseLeft weirdNote (date 2021 Mar 9)
+     Lifecycle.lifecycle spot chooseLeft weirdNote (date 2021 Mar 10)
   remaining === Zero
   pending === pure (1.0, a)
 
   -- For github issue #10
-  let outerScale : C = Scale (O.pure 2.0) $ When (at $ date 2021 Mar 9) (One a)
+  let outerScale : C = Scale (O.pure 2.0) $ When (at $ date 2021 Mar 11) (One a)
   Lifecycle.Result{remaining, pending} <-
     Lifecycle.lifecycle spot chooseLeft outerScale (date 1970 Jan 1)
   remaining === outerScale
   pending === mempty
   Lifecycle.Result{remaining, pending} <-
-    Lifecycle.lifecycle spot chooseLeft outerScale (date 2021 Mar 9)
+    Lifecycle.lifecycle spot chooseLeft outerScale (date 2021 Mar 11)
   remaining === Zero
   pending === pure (2.0, a)

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -72,3 +72,14 @@ lifecycling = script do
      Lifecycle.lifecycle spot chooseLeft weirdNote (date 2021 Mar 9)
   remaining === Zero
   pending === pure (1.0, a)
+
+  -- For github issue #10
+  let outerScale : C = Scale (O.pure 2.0) $ When (at $ date 2021 Mar 9) (One a)
+  Lifecycle.Result{remaining, pending} <-
+    Lifecycle.lifecycle spot chooseLeft outerScale (date 1970 Jan 1)
+  remaining === outerScale
+  pending === mempty
+  Lifecycle.Result{remaining, pending} <-
+    Lifecycle.lifecycle spot chooseLeft outerScale (date 2021 Mar 9)
+  remaining === Zero
+  pending === pure (2.0, a)


### PR DESCRIPTION
The lifecycle is now split into two parts, an effectful `lifecycle'`,
which calculates the payoff, and a pure `pruneZeros'` which reduces
any subtrees with the `Zero` identity.

The recursion has been changed to be top-down; this way, we can short-circuit branches which are not in scope.