### PR TITLE
Named vars

### DIFF
--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -9,7 +9,8 @@ import Prelude hiding (or, and)
 import Daml.Control.Recursion
 import ContingentClaims.Claim.Serializable qualified as Serialized
 import ContingentClaims.Observation (Observation)
-import qualified ContingentClaims.Observation as Observation (expiry)
+-- import qualified ContingentClaims.Observation as Observation (expiry)
+import ContingentClaims.Observable (Inequality)
 import DA.Set qualified as Set
 import DA.Foldable (Foldable(..))
 import DA.Traversable (Traversable(..))
@@ -22,31 +23,28 @@ type F = ClaimF
 -- | Used to model cashflows of instruments. 
 -- See [quickstart](../QUICKSTART.md) for detailed explanation.
 -- In Petyon-Jones' paper, this is called 'Contract'.
--- We renamed it to avoid ambiguity
--- * `f` is the effect, e.g. `(->)`
--- * `t` is time e.g. `Date`
--- * `a` is the asset
-data Claim f t a
+-- We renamed it to avoid ambiguity.
+-- * `f`, `t` and `x` correspond to the `Observable`, it's input and output, respectively.
+-- * `a` is the representation of an asset, e.g. a `Text` ISIN code.
+data Claim f t x a
   = Zero
       -- ^ Represents an absence of claims.
   | One a
       -- ^ The bearer acquires one unit of `a` *immediately*.
-  | Give (Claim f t a)
+  | Give (Claim f t x a)
       -- ^ The obligations of the bearer and issuer are revesed.
-  | And with lhs: Claim f t a, rhs: Claim f t a
+  | And with lhs: Claim f t x a, rhs: Claim f t x a
       -- ^ Used to combine multiple rights together.
-  | Or with lhs: Claim f t a, rhs: Claim f t a
+  | Or with lhs: Claim f t x a, rhs: Claim f t x a
       -- ^ Gives the bearer the right to choose between two claims.
-  | Cond with predicate: f t Bool, success: Claim f t a, failure: Claim f t a
+  | Cond with predicate: Inequality f t x, success: Claim f t x a, failure: Claim f t x a --TODO rename predicate -> `lte` or `inequality`
       -- ^ Gives the bearer the right to the first claim if `predicate` is true, else the second claim.
-  | Scale with k: f t Decimal, claim: Claim f t a
+  | Scale with k: f t x, claim: Claim f t x a
       -- ^ Multiplies the `claim` by `k` (which can be non-detrerministic).
-  | When with predicate: f t Bool, claim: Claim f t a
+  | When with predicate: Inequality f t x, claim: Claim f t x a
       -- ^ Defers the acquisition of `claim` until *the first instant* that `predicate` is true.
 
---  | Anytime with predicate: f t Bool, claim: Claim f t a
---  | Until with predicate: f t Bool, claim: Claim f t a
-
+{-
 -- | Return the upper time bound of the obligation; `None` if it cannot be determined.
 -- This is called `horizon` in the original paper.
 expiry : forall t a . Ord t => Claim Observation t a -> Optional t
@@ -61,9 +59,10 @@ expiry = cata \case
            WhenF p _ -> Observation.expiry p
 --           AnytimeF p _ -> Observation.expiry p
 --           UntilF p _ -> Observation.expiry p
+-}
 
 -- TODO: not sure these make sense
-executorOf : Party -> Party -> Claim f t a -> Set.Set Party
+executorOf : Party -> Party -> Claim f t x a -> Set.Set Party
 executorOf bearer cpty = cata \case
   ZeroF -> mempty
   OneF _ -> Set.singleton bearer
@@ -80,7 +79,7 @@ executorOf bearer cpty = cata \case
 --  UntilF _ p -> p
 
 -- TODO: not sure these make sense
-isBearerExecutor : forall f t a . Claim f t a -> Bool
+isBearerExecutor : forall f t x a . Claim f t x a -> Bool
 isBearerExecutor = cata \case
                     OneF _ -> True
                     GiveF p -> not p
@@ -91,11 +90,11 @@ isBearerExecutor = cata \case
                     _ -> error "Undefined: isBearerExecutor"
 
 -- | Converts a `Serialized.Claim` read from ledger, to a more general `Claim`, for use with `Daml.Control.Recursion`.
-deserialize : Serialized.Claim t a -> Claim Observation t a
+deserialize : Serialized.Claim t x a -> Claim Observation t x a
 deserialize = ana deserialize' 
 
 -- | F-algebra for `deserialize`; it can be composed in unfolds.
-deserialize' : Serialized.Claim t a -> ClaimF Observation t a (Serialized.Claim t a)
+deserialize' : Serialized.Claim t x a -> ClaimF Observation t x a (Serialized.Claim t x a)
 deserialize' Serialized.Zero = ZeroF
 deserialize' (Serialized.One a) = OneF a
 deserialize' (Serialized.Give c) = GiveF c
@@ -110,11 +109,11 @@ deserialize' (Serialized.When p c) = WhenF p c
 --  Serialized.Until p c = UntilF p c
 
 -- | Converts a `Claim` into a `Serializable.Claim`, so it can be written to the ledger.
-serialize : Claim Observation t a -> Serialized.Claim t a
+serialize : Claim Observation t x a -> Serialized.Claim t x a
 serialize = histo serialize'
 
 -- | F-coalgebra for `serialize`; it can be composed with other folds.
-serialize' : ClaimF Observation t a (Cofree (ClaimF Observation t a) (Serialized.Claim t a)) -> Serialized.Claim t a 
+serialize' : ClaimF Observation t x a (Cofree (ClaimF Observation t x a) (Serialized.Claim t x a)) -> Serialized.Claim t x a 
 serialize' ZeroF = Serialized.Zero
 serialize' (OneF a) = Serialized.One a
 serialize' (GiveF c) = Serialized.Give c.attribute
@@ -128,21 +127,21 @@ serialize' (WhenF p c) = Serialized.When p c.attribute
 --  Until p c -> Serialized.UntilF p c
 
 -- | Unfixed version of `Claim`, for use with `Daml.Control.Recursion`.
-data ClaimF f t a x
+data ClaimF f t x a b
   = ZeroF
   | OneF a
-  | GiveF x
-  | AndF with lhs: x, rhs: x
-  | OrF with lhs: x, rhs: x
-  | CondF with predicate: (f t Bool), success: x, failure: x
-  | ScaleF with k: (f t Decimal), claim: x
-  | WhenF with predicate: (f t Bool), claim: x
---  | AnytimeF with predicate: (f t Bool), claim: x
---  | UntilF with predicate: (f t Bool), claim: x
+  | GiveF b
+  | AndF with lhs: b, rhs: b
+  | OrF with lhs: b, rhs: b
+  | CondF with predicate: Inequality f t x, success: b, failure: b
+  | ScaleF with k: f t x, claim: b
+  | WhenF with predicate: Inequality f t x, claim: b
+--  | AnytimeF with predicate: (f t Bool), claim: b
+--  | UntilF with predicate: (f t Bool), claim: b
   deriving (Functor)
 
 -- TODO: rename variables to be consistent with the types
-instance Recursive (Claim f t a) (ClaimF f t a) where
+instance Recursive (Claim f t x a) (ClaimF f t x a) where
   project Zero = ZeroF
   project (One a) = OneF a
   project (Give c) = GiveF c
@@ -154,7 +153,7 @@ instance Recursive (Claim f t a) (ClaimF f t a) where
 --  project (Anytime o a) = AnytimeF o a
 --  project (Until o x) = UntilF o x
 
-instance Corecursive (Claim f t a) (ClaimF f t a) where
+instance Corecursive (Claim f t x a) (ClaimF f t x a) where
   embed ZeroF = Zero
   embed (OneF x) = One x
   embed (GiveF a) = Give a
@@ -166,7 +165,7 @@ instance Corecursive (Claim f t a) (ClaimF f t a) where
 --  embed (AnytimeF o x) = Anytime o x
 --  embed (UntilF o x) = Until o x
 
-instance Foldable (ClaimF f t a) where
+instance Foldable (ClaimF f t x a) where
   foldr _ seed ZeroF = seed
   foldr _ seed (OneF _) = seed
   foldr f seed (GiveF c) = f c seed
@@ -176,9 +175,9 @@ instance Foldable (ClaimF f t a) where
   foldr f seed (OrF c c') = f c $ f c' seed
   foldr f seed (CondF _ c c') = f c $ f c' seed
 
-instance Traversable (ClaimF g t x) where
+instance Traversable (ClaimF g t x b) where
   sequence ZeroF = pure ZeroF
-  sequence (OneF x) = pure $ OneF x
+  sequence (OneF asset) = pure $ OneF asset
   sequence (GiveF fa) = GiveF <$> fa
   sequence (WhenF p fa) = WhenF p <$> fa
   sequence (ScaleF p fa) = ScaleF p <$> fa

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -40,7 +40,7 @@ data Claim f t x a
   | Cond with predicate: Inequality f t x, success: Claim f t x a, failure: Claim f t x a --TODO rename predicate -> `lte` or `inequality`
       -- ^ Gives the bearer the right to the first claim if `predicate` is true, else the second claim.
   | Scale with k: f t x, claim: Claim f t x a
-      -- ^ Multiplies the `claim` by `k` (which can be non-detrerministic).
+      -- ^ Multiplies the `claim` by `k` (which can be non-deterministic).
   | When with predicate: Inequality f t x, claim: Claim f t x a
       -- ^ Defers the acquisition of `claim` until *the first instant* that `predicate` is true.
 

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -9,8 +9,8 @@ import Prelude hiding (or, and)
 import Daml.Control.Recursion
 import ContingentClaims.Claim.Serializable qualified as Serialized
 import ContingentClaims.Observation (Observation)
--- import qualified ContingentClaims.Observation as Observation (expiry)
-import ContingentClaims.Observable (Inequality(..))
+import ContingentClaims.Observable (Inequality(..), Param, Key)
+import ContingentClaims.Observable qualified as Observable
 import DA.Set qualified as Set
 import DA.Foldable (Foldable(..))
 import DA.Traversable (Traversable(..))
@@ -20,7 +20,7 @@ type F = ClaimF
 
 -- TODO: f should depend on t ?
 
--- | Used to model cashflows of instruments. 
+-- | Used to model cashflows of instruments.
 -- See [quickstart](../QUICKSTART.md) for detailed explanation.
 -- In Petyon-Jones' paper, this is called 'Contract'.
 -- We renamed it to avoid ambiguity.
@@ -43,6 +43,25 @@ data Claim f t x a
       -- ^ Multiplies the `claim` by `k` (which can be non-detrerministic).
   | When with predicate: Inequality f t x, claim: Claim f t x a
       -- ^ Defers the acquisition of `claim` until *the first instant* that `predicate` is true.
+
+-- | Replace parameters in an `Claim` with actual values.
+mapParams :  Observable.Interpret f
+          => (Param -> Key)
+          -> (Param -> Decimal)
+          -> Claim f t Param a -> Claim f t Decimal a
+mapParams fk fv =
+  let f = Observable.mapParams fk fv
+  in cata \case
+    ZeroF -> Zero
+    OneF a -> One a
+    GiveF c -> Give c
+    AndF c c' -> And c c'
+    OrF c c' -> Or c c'
+    CondF (Lte (x, x')) c c' -> Cond (Lte(f x, f x')) c c'
+    CondF (TimeGte t) c c' -> Cond (TimeGte t) c c'
+    ScaleF k c -> Scale (f k) c
+    WhenF (Lte (x, x')) c -> When (Lte (f x, f x')) c
+    WhenF (TimeGte t) c -> When (TimeGte t) c
 
 {-
 -- | Return the upper time bound of the obligation; `None` if it cannot be determined.
@@ -91,7 +110,7 @@ isBearerExecutor = cata \case
 
 -- | Converts a `Serialized.Claim` read from ledger, to a more general `Claim`, for use with `Daml.Control.Recursion`.
 deserialize : Serialized.Claim t x a -> Claim Observation t x a
-deserialize = ana deserialize' 
+deserialize = ana deserialize'
 
 -- | F-algebra for `deserialize`; it can be composed in unfolds.
 deserialize' : Serialized.Claim t x a -> ClaimF Observation t x a (Serialized.Claim t x a)

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -24,7 +24,7 @@ type F = ClaimF
 -- See [quickstart](../QUICKSTART.md) for detailed explanation.
 -- In Petyon-Jones' paper, this is called 'Contract'.
 -- We renamed it to avoid ambiguity.
--- * `f`, `t` and `x` correspond to the `Observable`, it's input and output, respectively.
+-- * `f`, `t` and `x` respectively correspond to the `Observable`, it's input type and the resulting output type.
 -- * `a` is the representation of an asset, e.g. a `Text` ISIN code.
 data Claim f t x a
   = Zero

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -63,6 +63,23 @@ mapParams fk fv =
     WhenF (Lte (x, x')) c -> When (Lte (f x, f x')) c
     WhenF (TimeGte t) c -> When (TimeGte t) c
 
+cmapTime : Observable.Interpret f
+         => (t -> i) -> (i -> t)
+         -> Claim f i x a -> Claim f t x a
+cmapTime g' f = 
+  let g = Observable.cmapTime g'
+  in ana \case
+    Zero -> ZeroF
+    One a -> OneF a
+    Give c -> GiveF c
+    And c c' -> AndF c c'
+    Or c c' -> OrF c c'
+    Cond (Lte (x, x')) c c' -> CondF (Lte(g x, g x')) c c'
+    Cond (TimeGte t) c c' -> CondF (TimeGte (f t)) c c'
+    Scale k c -> ScaleF (g k) c
+    When (Lte (x, x')) c -> WhenF (Lte (g x, g x')) c
+    When (TimeGte t) c -> WhenF (TimeGte (f t)) c
+
 {-
 -- | Return the upper time bound of the obligation; `None` if it cannot be determined.
 -- This is called `horizon` in the original paper.

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -77,6 +77,18 @@ expiry today = cata \case
 --           AnytimeF p _ -> Observation.expiry p
 --           UntilF p _ -> Observation.expiry p
 
+-- | Extract any fixing dates that can be analytically determined.
+-- An example of an expression which **can't** be determined would be:
+-- ```
+-- When (observe tempCelcius > 24.5) _
+-- ```
+fixings : forall f t x a . Ord t => t -> Claim f t x a -> Set.Set t
+fixings today = cata \case
+  ZeroF -> Set.fromList [today]
+  OneF _ -> Set.fromList [today]
+  WhenF (Observable.TimeGte t) _ -> Set.fromList [t]
+  other -> fold other
+
 -- TODO: not sure these make sense
 executorOf : Party -> Party -> Claim f t x a -> Set.Set Party
 executorOf bearer cpty = cata \case

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -10,7 +10,7 @@ import Daml.Control.Recursion
 import ContingentClaims.Claim.Serializable qualified as Serialized
 import ContingentClaims.Observation (Observation)
 -- import qualified ContingentClaims.Observation as Observation (expiry)
-import ContingentClaims.Observable (Inequality)
+import ContingentClaims.Observable (Inequality(..))
 import DA.Set qualified as Set
 import DA.Foldable (Foldable(..))
 import DA.Traversable (Traversable(..))
@@ -102,11 +102,19 @@ deserialize' (Serialized.And [c]) = deserialize'  c
 deserialize' (Serialized.And (c :: cs)) = AndF c (Serialized.And cs)
 deserialize' (Serialized.And []) = error "deserialize: Malformed `And` (should have at least two elements)"
 deserialize' (Serialized.Or c c') = OrF c c'
-deserialize' (Serialized.Cond k c c') = CondF k c c'
+deserialize' (Serialized.Cond k c c') = CondF (deserializeInequality k) c c'
 deserialize' (Serialized.Scale k c) = ScaleF k c
-deserialize' (Serialized.When p c) = WhenF p c
+deserialize' (Serialized.When p c) = WhenF (deserializeInequality p) c
 --  Serialized.Anytime p c = AnytimeF p c
 --  Serialized.Until p c = UntilF p c
+
+deserializeInequality : Serialized.Inequality t x -> Inequality Observation t x
+deserializeInequality (Serialized.TimeLte t) = TimeLte t
+deserializeInequality (Serialized.Lte (f, f')) = Lte (f, f')
+
+serializeInequality : Inequality Observation t x -> Serialized.Inequality t x
+serializeInequality (TimeLte t) = Serialized.TimeLte t
+serializeInequality (Lte (f, f')) = Serialized.Lte (f, f')
 
 -- | Converts a `Claim` into a `Serializable.Claim`, so it can be written to the ledger.
 serialize : Claim Observation t x a -> Serialized.Claim t x a
@@ -120,9 +128,9 @@ serialize' (GiveF c) = Serialized.Give c.attribute
 serialize' (AndF c (Cofree (Serialized.And cs) _) ) = Serialized.And $ c.attribute :: cs
 serialize' (AndF c c') = Serialized.And [c.attribute, c'.attribute]
 serialize' (OrF c c') = Serialized.Or c.attribute c'.attribute
-serialize' (CondF k c c') = Serialized.Cond k c.attribute c'.attribute
+serialize' (CondF k c c') = Serialized.Cond (serializeInequality k) c.attribute c'.attribute
 serialize' (ScaleF k c) = Serialized.Scale k c.attribute
-serialize' (WhenF p c) = Serialized.When p c.attribute
+serialize' (WhenF p c) = Serialized.When (serializeInequality p) c.attribute
 --  Anytime p c -> Serialized.AnytimeF p c
 --  Until p c -> Serialized.UntilF p c
 

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -109,11 +109,11 @@ deserialize' (Serialized.When p c) = WhenF (deserializeInequality p) c
 --  Serialized.Until p c = UntilF p c
 
 deserializeInequality : Serialized.Inequality t x -> Inequality Observation t x
-deserializeInequality (Serialized.TimeLte t) = TimeLte t
+deserializeInequality (Serialized.TimeGte t) = TimeGte t
 deserializeInequality (Serialized.Lte (f, f')) = Lte (f, f')
 
 serializeInequality : Inequality Observation t x -> Serialized.Inequality t x
-serializeInequality (TimeLte t) = Serialized.TimeLte t
+serializeInequality (TimeGte t) = Serialized.TimeGte t
 serializeInequality (Lte (f, f')) = Serialized.Lte (f, f')
 
 -- | Converts a `Claim` into a `Serializable.Claim`, so it can be written to the ledger.

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -46,11 +46,13 @@ data Claim f t x a
 
 -- | Replace parameters in an `Claim` with actual values.
 mapParams :  Observable.Interpret f
-          => (Param -> Key)
+          => (t -> i)
+          -> (i -> t)
+          -> (Param -> Key)
           -> (Param -> Decimal)
-          -> Claim f t Param a -> Claim f t Decimal a
-mapParams fk fv =
-  let f = Observable.mapParams fk fv
+          -> Claim f i Param a -> Claim f t Decimal a
+mapParams ft' ft fk fv =
+  let f = Observable.mapParams ft' fk fv
   in cata \case
     ZeroF -> Zero
     OneF a -> One a
@@ -58,27 +60,10 @@ mapParams fk fv =
     AndF c c' -> And c c'
     OrF c c' -> Or c c'
     CondF (Lte (x, x')) c c' -> Cond (Lte(f x, f x')) c c'
-    CondF (TimeGte t) c c' -> Cond (TimeGte t) c c'
+    CondF (TimeGte t) c c' -> Cond (TimeGte (ft t)) c c'
     ScaleF k c -> Scale (f k) c
     WhenF (Lte (x, x')) c -> When (Lte (f x, f x')) c
-    WhenF (TimeGte t) c -> When (TimeGte t) c
-
-cmapTime : Observable.Interpret f
-         => (t -> i) -> (i -> t)
-         -> Claim f i x a -> Claim f t x a
-cmapTime g' f = 
-  let g = Observable.cmapTime g'
-  in ana \case
-    Zero -> ZeroF
-    One a -> OneF a
-    Give c -> GiveF c
-    And c c' -> AndF c c'
-    Or c c' -> OrF c c'
-    Cond (Lte (x, x')) c c' -> CondF (Lte(g x, g x')) c c'
-    Cond (TimeGte t) c c' -> CondF (TimeGte (f t)) c c'
-    Scale k c -> ScaleF (g k) c
-    When (Lte (x, x')) c -> WhenF (Lte (g x, g x')) c
-    When (TimeGte t) c -> WhenF (TimeGte (f t)) c
+    WhenF (TimeGte t) c -> When (TimeGte (ft t)) c
 
 {-
 -- | Return the upper time bound of the obligation; `None` if it cannot be determined.

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -65,22 +65,17 @@ mapParams ft' ft fk fv =
     WhenF (Lte (x, x')) c -> When (Lte (f x, f x')) c
     WhenF (TimeGte t) c -> When (TimeGte (ft t)) c
 
-{-
 -- | Return the upper time bound of the obligation; `None` if it cannot be determined.
 -- This is called `horizon` in the original paper.
-expiry : forall t a . Ord t => Claim Observation t a -> Optional t
-expiry = cata \case
-           ZeroF -> None
-           OneF _ -> None
-           GiveF t -> t
-           AndF t t' -> liftA2 max t t'
-           OrF t t' -> liftA2 max t t'
-           CondF _ t t' -> liftA2 max t t'
-           ScaleF _ t -> t
-           WhenF p _ -> Observation.expiry p
+expiry : forall f t x a . Ord t => t -> Claim f t x a -> Optional t
+expiry today = cata \case
+  ZeroF -> Some today
+  OneF _ -> Some today
+  WhenF (Observable.TimeGte t) _ -> Some t
+  WhenF (Observable.Lte _) _ -> None -- technically, we _can_ determine this if it's a pure fn.
+  other -> maximum other
 --           AnytimeF p _ -> Observation.expiry p
 --           UntilF p _ -> Observation.expiry p
--}
 
 -- TODO: not sure these make sense
 executorOf : Party -> Party -> Claim f t x a -> Set.Set Party

--- a/daml/ContingentClaims/Claim/Serializable.daml
+++ b/daml/ContingentClaims/Claim/Serializable.daml
@@ -6,6 +6,7 @@
 module ContingentClaims.Claim.Serializable where 
 
 import ContingentClaims.Observation
+import ContingentClaims.Observable (Inequality)
 import Daml.Control.Recursion
 
 type T = Claim
@@ -14,44 +15,44 @@ type F = ClaimF
 -- | We require a separate data type for a serializable claim, because DAML
 -- does not support serialization of higher kinds. i.e. the `f` in `Claim`.
 -- Here we replace it with the concrete `Observation`.
-data Claim t a 
+data Claim t x a 
   = Zero 
       -- ^ Represents an absence of claims.
   | One a 
       -- ^ The bearer acquires one unit of `a` *immediately*.
-  | Give (Claim t a)
+  | Give (Claim t x a)
       -- ^ The obligations of the bearer and issuer are revesed.
-  | And with claims : [Claim t a]
+  | And with claims : [Claim t x a]
       -- ^ Used to combine multiple rights together. 
       --   __Note__ This serialized version flattens right-associative `And`s to mitigate language recursion limits.
-  | Or with lhs: Claim t a, rhs: Claim t a 
+  | Or with lhs: Claim t x a, rhs: Claim t x a 
       -- ^ Gives the bearer the right to choose between two claims.
-  | Cond with predicate: Observation t Bool, success: Claim t a, failure: Claim t a 
+  | Cond with predicate: Inequality Observation t x, success: Claim t x a, failure: Claim t x a 
       -- ^ Gives the bearer the right to the first claim if `predicate` is true, else the second claim.
-  | Scale with k: Observation t Decimal, claim: Claim t a 
+  | Scale with k: Observation t x, claim: Claim t x a 
       -- ^ Multiplies the `claim` by `k` (which can be non-detrerministic).
-  | When with predicate: Observation t Bool, claim: Claim t a 
+  | When with predicate: Inequality Observation t x, claim: Claim t x a 
       -- ^ Defers the acquisition of `claim` until *the first instant* that `predicate` is true.
 
---  | Anytime with predicate: Observation t Bool, claim: Claim t a
---  | Until with predicate: Observation t Bool, claim: Claim t a
+--  | Anytime with predicate: Observation t Bool, claim: Claim t x a
+--  | Until with predicate: Observation t Bool, claim: Claim t x a
   deriving (Eq, Show, Functor)
 
 -- | Unfixed version of `Claim`, for use with `Daml.Control.Recursion`.
-data ClaimF t a x
+data ClaimF t x a b
   = ZeroF
   | OneF a
-  | GiveF x
-  | AndF with claims: [x]
-  | OrF with lhs: x, rhs: x
-  | CondF with predicate: (Observation t Bool), success: x, failure: x
-  | ScaleF with k: (Observation t Decimal), claim: x
-  | WhenF with predicate: (Observation t Bool), claim: x
+  | GiveF b
+  | AndF with claims: [b]
+  | OrF with lhs: b, rhs: b
+  | CondF with predicate: Inequality Observation t x, success: b, failure: b
+  | ScaleF with k: Observation t x, claim: b
+  | WhenF with predicate: Inequality Observation t x, claim: b
 --   | AnytimeF with predicate: (Observation t Bool), claim: x
 --   | UntilF with predicate: (Observation t Bool), claim: x
   deriving Functor
 
-instance Recursive (Claim t a) (ClaimF t a) where
+instance Recursive (Claim t x a) (ClaimF t x a) where
   project Zero = ZeroF
   project (One a) = OneF a
   project (Give c) = GiveF c
@@ -63,7 +64,7 @@ instance Recursive (Claim t a) (ClaimF t a) where
 --  project (Anytime o x) = AnytimeF o x
 --  project (Until o x) = UntilF o x
 
-instance Corecursive (Claim t a) (ClaimF t a) where
+instance Corecursive (Claim t x a) (ClaimF t x a) where
   embed ZeroF = Zero
   embed (OneF a) = One a
   embed (GiveF c) = Give c

--- a/daml/ContingentClaims/Claim/Serializable.daml
+++ b/daml/ContingentClaims/Claim/Serializable.daml
@@ -38,7 +38,7 @@ data Claim t x a
   deriving (Eq, Show, Functor)
 
 -- | Serializable version of `Observable.Inequality`
-data Inequality t x = TimeLte t | Lte (Observation t x, Observation t x)
+data Inequality t x = TimeGte t | Lte (Observation t x, Observation t x)
 
 deriving instance (Eq t, Eq x) => Eq (Inequality t x)
 

--- a/daml/ContingentClaims/Claim/Serializable.daml
+++ b/daml/ContingentClaims/Claim/Serializable.daml
@@ -6,7 +6,6 @@
 module ContingentClaims.Claim.Serializable where 
 
 import ContingentClaims.Observation
-import ContingentClaims.Observable (Inequality)
 import Daml.Control.Recursion
 
 type T = Claim
@@ -15,28 +14,35 @@ type F = ClaimF
 -- | We require a separate data type for a serializable claim, because DAML
 -- does not support serialization of higher kinds. i.e. the `f` in `Claim`.
 -- Here we replace it with the concrete `Observation`.
-data Claim t x a 
-  = Zero 
+data Claim t x a
+  = Zero
       -- ^ Represents an absence of claims.
-  | One a 
+  | One a
       -- ^ The bearer acquires one unit of `a` *immediately*.
   | Give (Claim t x a)
       -- ^ The obligations of the bearer and issuer are revesed.
   | And with claims : [Claim t x a]
-      -- ^ Used to combine multiple rights together. 
+      -- ^ Used to combine multiple rights together.
       --   __Note__ This serialized version flattens right-associative `And`s to mitigate language recursion limits.
-  | Or with lhs: Claim t x a, rhs: Claim t x a 
+  | Or with lhs: Claim t x a, rhs: Claim t x a
       -- ^ Gives the bearer the right to choose between two claims.
-  | Cond with predicate: Inequality Observation t x, success: Claim t x a, failure: Claim t x a 
+  | Cond with predicate: Inequality t x, success: Claim t x a, failure: Claim t x a
       -- ^ Gives the bearer the right to the first claim if `predicate` is true, else the second claim.
-  | Scale with k: Observation t x, claim: Claim t x a 
+  | Scale with k: Observation t x, claim: Claim t x a
       -- ^ Multiplies the `claim` by `k` (which can be non-detrerministic).
-  | When with predicate: Inequality Observation t x, claim: Claim t x a 
+  | When with predicate: Inequality t x, claim: Claim t x a
       -- ^ Defers the acquisition of `claim` until *the first instant* that `predicate` is true.
 
 --  | Anytime with predicate: Observation t Bool, claim: Claim t x a
 --  | Until with predicate: Observation t Bool, claim: Claim t x a
   deriving (Eq, Show, Functor)
+
+-- | Serializable version of `Observable.Inequality`
+data Inequality t x = TimeLte t | Lte (Observation t x, Observation t x)
+
+deriving instance (Eq t, Eq x) => Eq (Inequality t x)
+
+deriving instance (Show t, Show x) => Show (Inequality t x)
 
 -- | Unfixed version of `Claim`, for use with `Daml.Control.Recursion`.
 data ClaimF t x a b
@@ -45,9 +51,9 @@ data ClaimF t x a b
   | GiveF b
   | AndF with claims: [b]
   | OrF with lhs: b, rhs: b
-  | CondF with predicate: Inequality Observation t x, success: b, failure: b
+  | CondF with predicate: Inequality t x, success: b, failure: b
   | ScaleF with k: Observation t x, claim: b
-  | WhenF with predicate: Inequality Observation t x, claim: b
+  | WhenF with predicate: Inequality t x, claim: b
 --   | AnytimeF with predicate: (Observation t Bool), claim: x
 --   | UntilF with predicate: (Observation t Bool), claim: x
   deriving Functor

--- a/daml/ContingentClaims/FinancialClaim.daml
+++ b/daml/ContingentClaims/FinancialClaim.daml
@@ -8,7 +8,7 @@ module ContingentClaims.FinancialClaim where
 import Prelude hiding (and, or, time)
 import ContingentClaims.Claim
 import ContingentClaims.Observable qualified as O
-import ContingentClaims.Observable (TimeF, PointF, InequalityF, Observable)
+import ContingentClaims.Observable (TimeF, PointF, Observable)
 import Daml.Control.Recursion
 import DA.Date (date, Month)
 
@@ -20,25 +20,23 @@ unrollDates issueYear maturityYear fixingMonths fixingDay =
   date <$> [issueYear .. maturityYear] <*> fixingMonths <*> [fixingDay]
 
 -- | Observable that is true on the passed time. i.e. identity for the time observable.
-at
-  : forall f t . (TimeF f t, PointF f t t, InequalityF f t t)
-  => t -> f t Bool
-at t = O.time O.== (O.pure t)
+at : (TimeF f t, PointF f t t) => t -> O.Inequality f t x
+at t = O.LteT (O.time, O.pure t)
 
 -- | Forward agreement. Discounted by (potentially stochastic) interest rate `r`.
-forward : Observable f t => t -> f t Decimal -> Claim f t a -> Claim f t a
+forward : Observable f t x => t -> f t x -> Claim f t x a -> Claim f t x a
 forward maturity r payoff = When (at maturity) $ Scale r payoff
 
 -- | Forward rate agreement. 
-fra : Observable f t => t -> t -> f t Decimal -> f t Decimal -> Claim f t a -> Claim f t a
+fra : Observable f t x => t -> t -> f t x -> f t x -> Claim f t x a -> Claim f t x a
 fra t₁ t₂ r₀ r₁ = forward t₁ r₀ . forward t₂ r₁
 
 -- | Zero Coupon Bond.
-zcb : Observable f t => t -> Decimal -> ccy -> Claim f t ccy
+zcb : Observable f t x => t -> x -> ccy -> Claim f t x ccy
 zcb maturity principal ccy = forward maturity (O.pure principal) (One ccy)
 
 -- | A floating rate bond. The first two arguments are `Observable`s.
-floating : Observable f t => f t Decimal -> f t Decimal -> ccy -> [t] -> Claim f t ccy
+floating : Observable f t x => f t x -> f t x -> ccy -> [t] -> Claim f t x ccy
 floating principal coupon asset = apo \case
      [maturity] -> Left (forward maturity coupon (One asset)) `AndF` 
                    Left (forward maturity principal (One asset))
@@ -46,22 +44,18 @@ floating principal coupon asset = apo \case
      [] -> ZeroF
 
 -- | A (fixed rate) coupon paying bond.
-fixed : Observable f t => Decimal -> Decimal -> ccy -> [t] -> Claim f t ccy
+fixed : Observable f t x => x -> x -> ccy -> [t] -> Claim f t x ccy
 fixed principal coupon = floating (O.pure principal) (O.pure coupon)
 
 -- | European option on the passed claim. e.g. call option on S&P 500:
 -- ```
 -- european (at $ date 2021 05 14) (Zero `Or` observe "SPX" - pure 4200)
 -- ```
-european
-  : forall f t a . (TimeF f t, PointF f t t, InequalityF f t t)
-  => t -> Claim f t a -> Claim f t a
+european : (TimeF f t, PointF f t t) => t -> Claim f t x a -> Claim f t x a
 european t u = When (at t) (u `Or` Zero)
 
 -- | Bermudan option on the passed claim.
-bermudan
-  : forall f t a . (TimeF f t, PointF f t t, InequalityF f t t)
-  => Claim f t a -> [t] -> Claim f t a
+bermudan : (TimeF f t, PointF f t t) => Claim f t x a -> [t] -> Claim f t x a
 bermudan u = apo \case
   (t :: ts) -> Left (european t u) `OrF` Right ts
   [] -> ZeroF
@@ -71,18 +65,5 @@ bermudan u = apo \case
 -- fixedUsdVsFloatingEur : [t] -> Serializable.Claim Text 
 -- fixedUsdVsFloatingEur = fixed 100.0 0.02 "USD" `swap` floating (observe "USDEUR" * pure 100.0) (observe "EUR1M") "EUR"
 -- ```
-swap : forall f t a . ([t] -> Claim f t a) -> ([t] -> Claim f t a) -> [t] -> Claim f t a
+swap : ([t] -> Claim f t x a) -> ([t] -> Claim f t x a) -> [t] -> Claim f t x a
 swap receive pay ts = receive ts `And` Give (pay ts)
-
-{-
-between
-  : forall f t a . (TimeF f t, PointF f t t, InequalityF (f t) t, LogicF (f t))
-  => t -> t -> f t Bool
-between t t' = liftA2 (&&) (O.time O.>= O.pure t) O.&&  (O.time O.<= O.pure t')
-
-american
-  : forall f t a . (Ord t, Category f, Applicative (f t))
-  => t -> t -> Claim f t a -> Claim f t a
-american t t' u = anytime (between t t') u
-
--}

--- a/daml/ContingentClaims/FinancialClaim.daml
+++ b/daml/ContingentClaims/FinancialClaim.daml
@@ -21,7 +21,7 @@ unrollDates issueYear maturityYear fixingMonths fixingDay =
 
 -- | Observable that is true on the passed time. i.e. identity for the time observable.
 at : t -> O.Inequality f t x
-at t = O.TimeLte t
+at t = O.TimeGte t
 
 -- | Forward agreement. Discounted by (potentially stochastic) interest rate `r`.
 forward : Observable f t x => t -> f t x -> Claim f t x a -> Claim f t x a

--- a/daml/ContingentClaims/FinancialClaim.daml
+++ b/daml/ContingentClaims/FinancialClaim.daml
@@ -8,7 +8,7 @@ module ContingentClaims.FinancialClaim where
 import Prelude hiding (and, or, time)
 import ContingentClaims.Claim
 import ContingentClaims.Observable qualified as O
-import ContingentClaims.Observable (TimeF, PointF, Observable)
+import ContingentClaims.Observable (Observable)
 import Daml.Control.Recursion
 import DA.Date (date, Month)
 
@@ -20,8 +20,8 @@ unrollDates issueYear maturityYear fixingMonths fixingDay =
   date <$> [issueYear .. maturityYear] <*> fixingMonths <*> [fixingDay]
 
 -- | Observable that is true on the passed time. i.e. identity for the time observable.
-at : (TimeF f t, PointF f t t) => t -> O.Inequality f t x
-at t = O.LteT (O.time, O.pure t)
+at : t -> O.Inequality f t x
+at t = O.TimeLte t
 
 -- | Forward agreement. Discounted by (potentially stochastic) interest rate `r`.
 forward : Observable f t x => t -> f t x -> Claim f t x a -> Claim f t x a
@@ -51,11 +51,11 @@ fixed principal coupon = floating (O.pure principal) (O.pure coupon)
 -- ```
 -- european (at $ date 2021 05 14) (Zero `Or` observe "SPX" - pure 4200)
 -- ```
-european : (TimeF f t, PointF f t t) => t -> Claim f t x a -> Claim f t x a
+european : t -> Claim f t x a -> Claim f t x a -- TODO : consider swapping ordre of parameters for consistency with bermudan?
 european t u = When (at t) (u `Or` Zero)
 
 -- | Bermudan option on the passed claim.
-bermudan : (TimeF f t, PointF f t t) => Claim f t x a -> [t] -> Claim f t x a
+bermudan : Claim f t x a -> [t] -> Claim f t x a
 bermudan u = apo \case
   (t :: ts) -> Left (european t u) `OrF` Right ts
   [] -> ZeroF

--- a/daml/ContingentClaims/FinancialClaim.daml
+++ b/daml/ContingentClaims/FinancialClaim.daml
@@ -5,10 +5,10 @@
 
 module ContingentClaims.FinancialClaim where
 
-import Prelude hiding (and, or, time)
+import Prelude hiding (and, or, (<=))
 import ContingentClaims.Claim
 import ContingentClaims.Observable qualified as O
-import ContingentClaims.Observable (Observable)
+import ContingentClaims.Observable (Observable, at)
 import Daml.Control.Recursion
 import DA.Date (date, Month)
 
@@ -18,10 +18,6 @@ import DA.Date (date, Month)
 unrollDates : Int -> Int -> [Month] -> Int -> [Date]
 unrollDates issueYear maturityYear fixingMonths fixingDay =
   date <$> [issueYear .. maturityYear] <*> fixingMonths <*> [fixingDay]
-
--- | Observable that is true on the passed time. i.e. identity for the time observable.
-at : t -> O.Inequality f t x
-at t = O.TimeGte t
 
 -- | Forward agreement. Discounted by (potentially stochastic) interest rate `r`.
 forward : Observable f t x => t -> f t x -> Claim f t x a -> Claim f t x a

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -13,8 +13,8 @@ module ContingentClaims.Lifecycle (
 ) where
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
-import ContingentClaims.Observation (Observation, eval)
-import ContingentClaims.Observation (evalInequality)
+import ContingentClaims.Observation (Observation)
+import ContingentClaims.Observable (Interpret(..))
 import ContingentClaims.Recursion (apoCataM)
 import ContingentClaims.Util (pruneZeros')
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
@@ -23,7 +23,7 @@ import Daml.Control.Monad.MonadWriter (MonadWriter(..))
 import Daml.Control.Monad.MonadState (MonadState(..), modify)
 import Daml.Control.Monad.Trans
 import Daml.Control.Arrow (Kleisli(..))
-import Prelude hiding (sequence, mapA)
+import Prelude hiding (sequence, mapA, compare)
 
 type C a = Claim Observation Date Decimal a
 type F a = ClaimF Observation Date Decimal a
@@ -70,7 +70,7 @@ lifecycle' _ _ (Give c) = do
   modify negate 
   pure $ GiveF (Right c)
 lifecycle' spot _ (When obs c) = do
-  predicate <- lift . lift $ evalInequality spot obs
+  predicate <- lift . lift $ compare spot obs
   pure $ if predicate then WhenF obs (Right c) else WhenF obs (Left c)
 lifecycle' spot _ (Scale obs c) = do
   k <- lift . lift $ eval spot obs
@@ -83,5 +83,5 @@ lifecycle' spot choose (Or c c') = do
      | otherwise -> abort "lifecycle: Invalid branch election"
 lifecycle' _ _ (And c c') = pure $ AndF (Right c) (Right c')
 lifecycle' spot choose (Cond obs c c') = do
-  predicate <- lift . lift $ evalInequality spot obs
+  predicate <- lift . lift $ compare spot obs
   if predicate then lifecycle' spot choose c else lifecycle' spot choose c'

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -14,7 +14,9 @@ module ContingentClaims.Lifecycle (
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation, eval)
-import ContingentClaims.Util (apoCataM, pruneZeros')
+import ContingentClaims.Observable (evalInequality)
+import ContingentClaims.Recursion (apoCataM)
+import ContingentClaims.Util (pruneZeros')
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
 import Daml.Control.Monad.State (StateT(..), evalStateT)
 import Daml.Control.Monad.MonadWriter (MonadWriter(..))
@@ -23,8 +25,8 @@ import Daml.Control.Monad.Trans
 import Daml.Control.Arrow (Kleisli(..))
 import Prelude hiding (sequence, mapA)
 
-type C a = Claim Observation Date a
-type F a = ClaimF Observation Date a
+type C a = Claim Observation Date Decimal a
+type F a = ClaimF Observation Date Decimal a
 
 deriving instance Eq a => Eq (C a)
 
@@ -68,10 +70,10 @@ lifecycle' _ _ (Give c) = do
   modify negate 
   pure $ GiveF (Right c)
 lifecycle' spot _ (When obs c) = do
-  predicate <- lift . lift $ eval spot obs
+  predicate <- lift . lift $ eval _ spot obs
   pure $ if predicate then WhenF obs (Right c) else WhenF obs (Left c)
 lifecycle' spot _ (Scale obs c) = do
-  k <- lift . lift $ eval spot obs
+  k <- lift . lift $ eval _ spot obs
   modify (* k) 
   pure $ ScaleF obs (Right c)
 lifecycle' spot choose (Or c c') = do
@@ -81,5 +83,5 @@ lifecycle' spot choose (Or c c') = do
      | otherwise -> abort "lifecycle: Invalid branch election"
 lifecycle' _ _ (And c c') = pure $ AndF (Right c) (Right c')
 lifecycle' spot choose (Cond obs c c') = do
-  predicate <- lift . lift $ eval spot obs
+  predicate <- lift . lift $ eval _ spot obs
   if predicate then lifecycle' spot choose c else lifecycle' spot choose c'

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -14,7 +14,7 @@ module ContingentClaims.Lifecycle (
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation, eval)
-import ContingentClaims.Observable (evalInequality)
+import ContingentClaims.Observation (evalInequality)
 import ContingentClaims.Recursion (apoCataM)
 import ContingentClaims.Util (pruneZeros')
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
@@ -70,10 +70,10 @@ lifecycle' _ _ (Give c) = do
   modify negate 
   pure $ GiveF (Right c)
 lifecycle' spot _ (When obs c) = do
-  predicate <- lift . lift $ eval _ spot obs
+  predicate <- lift . lift $ evalInequality spot obs
   pure $ if predicate then WhenF obs (Right c) else WhenF obs (Left c)
 lifecycle' spot _ (Scale obs c) = do
-  k <- lift . lift $ eval _ spot obs
+  k <- lift . lift $ eval spot obs
   modify (* k) 
   pure $ ScaleF obs (Right c)
 lifecycle' spot choose (Or c c') = do
@@ -83,5 +83,5 @@ lifecycle' spot choose (Or c c') = do
      | otherwise -> abort "lifecycle: Invalid branch election"
 lifecycle' _ _ (And c c') = pure $ AndF (Right c) (Right c')
 lifecycle' spot choose (Cond obs c c') = do
-  predicate <- lift . lift $ eval _ spot obs
+  predicate <- lift . lift $ evalInequality spot obs
   if predicate then lifecycle' spot choose c else lifecycle' spot choose c'

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -15,7 +15,7 @@ module ContingentClaims.Lifecycle (
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
 import ContingentClaims.Observation (Observation)
 import ContingentClaims.Observable (Interpret(..))
-import ContingentClaims.Recursion (apoCataM)
+import ContingentClaims.Util.Recursion (apoCataM)
 import ContingentClaims.Util (pruneZeros')
 import Daml.Control.Monad.Writer (WriterT, runWriterT)
 import Daml.Control.Monad.State (StateT(..), evalStateT)

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -3,8 +3,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 --
 
-{-# LANGUAGE UndecidableInstances #-}
-
 module ContingentClaims.Observable where
 
 import Prelude hiding (pure)

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -3,45 +3,33 @@
 -- SPDX-License-Identifier: Apache-2.0
 --
 
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module ContingentClaims.Observable where
 
-import Prelude (Bool, Decimal)
+import Prelude hiding (pure)
 
-infixl 6 +
-infixl 6 -
-infixl 7 *
-infixl 7 /
+type Key = Text
 
-type Observable f t = (TimeF f t,
+type Observable f t x = (TimeF f t,
   PointF f t t,
-  PointF f t Decimal,
-  RingF f t Decimal,
-  InequalityF f t Decimal,
-  InequalityF f t t)
+  PointF f t x,
+  Number (f t x))
+
+-- | Think of this as `f t t ≤ f t t | f t x ≤ f t x`
+data Inequality f t x = LteT (f t t, f t t) | LteX (f t x, f t x)
+
+evalInequality : Inequality f t x -> f t Bool
+evalInequality (LteT (f, f')) = undefined
+evalInequality (LteX (f, f')) = undefined
+
+deriving instance (Eq (f t t), Eq (f t x)) => Eq (Inequality f t x)
+
+deriving instance (Show (f t t), Show (f t x)) => Show (Inequality f t x)
 
 class TimeF f t where
   time : f t t
 
 class PointF f t a where
   pure : a -> f t a
-
-class RingF f t a where
-  zero : f t a
-  one : f t a
-  (+) : f t a -> f t a -> f t a
-  negate : f t a -> f t a
-  (-) : f t a -> f t a -> f t a
-  x - y = x + ContingentClaims.Observable.negate y
-  (*) : f t a -> f t a -> f t a
-  (/) : f t a -> f t a -> f t a
-
-class InequalityF f t a where
-  (<=) : f t a -> f t a -> f t Bool
-  (==) : f t a -> f t a -> f t Bool
-
-{-
-class LogicF f where
-  (&&) : f Bool -> f Bool -> f Bool
--}
+  observe : Key -> f t a

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -33,6 +33,7 @@ class Interpret f where
   compare : (Ord t, Ord x, Number x, Divisible x, Action m) => (Key -> t -> m x) -> Inequality f t x -> Kleisli m t Bool
   -- | The functor map operation _and_ also map any parametrs to keys.
   -- For example, could map the param "spot" to an ISIN code "GB123456789".
+  -- Also contra-maps time parameter, i.e. from relative time values to absolute ones.
   --
   -- @ mapParams identity = fmap
   --

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -11,24 +11,13 @@ import Prelude hiding (pure)
 
 type Key = Text
 
-type Observable f t x = (TimeF f t,
-  PointF f t t,
-  PointF f t x,
-  Number (f t x))
+type Observable f t x = (PointF f t x , Number (f t x), Divisible (f t x))
 
--- | Think of this as `f t t ≤ f t t | f t x ≤ f t x`
-data Inequality f t x = LteT (f t t, f t t) | LteX (f t x, f t x)
+data Inequality f t x = TimeLte t | Lte (f t x, f t x)
 
-evalInequality : Inequality f t x -> f t Bool
-evalInequality (LteT (f, f')) = undefined
-evalInequality (LteX (f, f')) = undefined
+deriving instance (Eq t, Eq (f t x)) => Eq (Inequality f t x)
 
-deriving instance (Eq (f t t), Eq (f t x)) => Eq (Inequality f t x)
-
-deriving instance (Show (f t t), Show (f t x)) => Show (Inequality f t x)
-
-class TimeF f t where
-  time : f t t
+deriving instance (Show t, Show (f t x)) => Show (Inequality f t x)
 
 class PointF f t a where
   pure : a -> f t a

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -12,7 +12,7 @@ import Daml.Control.Arrow (Kleisli(..))
 
 type Key = Text
 
-type Observable f t x = (PointF f t x , Number (f t x), Divisible (f t x))
+type Observable f t x = (Point f t x , Number (f t x), Divisible (f t x))
 
 data Inequality f t x = TimeLte t | Lte (f t x, f t x)
 
@@ -20,7 +20,7 @@ deriving instance (Eq t, Eq (f t x)) => Eq (Inequality f t x)
 
 deriving instance (Show t, Show (f t x)) => Show (Inequality f t x)
 
-class PointF f t x where
+class Point f t x where
   pure : x -> f t x
   observe : Key -> f t x
 

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -14,7 +14,8 @@ type Key = Text
 
 type Observable f t x = (Point f t x , Number (f t x), Divisible (f t x))
 
-data Inequality f t x = TimeLte t | Lte (f t x, f t x)
+-- | This is either `time ≥ t | f t x ≤ f t x`
+data Inequality f t x = TimeGte t | Lte (f t x, f t x)
 
 deriving instance (Eq t, Eq (f t x)) => Eq (Inequality f t x)
 

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -8,6 +8,7 @@
 module ContingentClaims.Observable where
 
 import Prelude hiding (pure)
+import Daml.Control.Arrow (Kleisli(..))
 
 type Key = Text
 
@@ -19,6 +20,10 @@ deriving instance (Eq t, Eq (f t x)) => Eq (Inequality f t x)
 
 deriving instance (Show t, Show (f t x)) => Show (Inequality f t x)
 
-class PointF f t a where
-  pure : a -> f t a
-  observe : Key -> f t a
+class PointF f t x where
+  pure : x -> f t x
+  observe : Key -> f t x
+
+class Interpret f where
+  eval : (Number x, Divisible x, Action m) => (Key -> t -> m x) -> f t x -> Kleisli m t x
+  compare : (Ord t, Ord x, Number x, Divisible x, Action m) => (Key -> t -> m x) -> Inequality f t x -> Kleisli m t Bool

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -15,6 +15,15 @@ type Observable f t x = (Point f t x , Number (f t x), Divisible (f t x))
 -- | This is either `time ≥ t | f t x ≤ f t x`
 data Inequality f t x = TimeGte t | Lte (f t x, f t x)
 
+-- | Observable that is true on the passed time. i.e. identity for the time observable.
+at : t -> Inequality f t x
+at t = TimeGte t
+
+infix 4 <=
+-- | `import Prelude hiding ((<=))` in order to use this.
+(<=) : f t x -> f t x -> Inequality f t x
+(<=) = curry Lte
+
 deriving instance (Eq t, Eq (f t x)) => Eq (Inequality f t x)
 
 deriving instance (Show t, Show (f t x)) => Show (Inequality f t x)

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -11,7 +11,7 @@ import Prelude hiding (pure)
 import Daml.Control.Arrow (Kleisli(..))
 
 type Key = Text
-
+type Param = Text
 type Observable f t x = (Point f t x , Number (f t x), Divisible (f t x))
 
 -- | This is either `time ≥ t | f t x ≤ f t x`
@@ -26,5 +26,16 @@ class Point f t x where
   observe : Key -> f t x
 
 class Interpret f where
+  -- | Reify the `Observable` into a Kleisli function. 
+  -- The function is only total when the first argument is too (typically it will fail on `t` > today).
   eval : (Number x, Divisible x, Action m) => (Key -> t -> m x) -> f t x -> Kleisli m t x
+  -- | Reify the `Observable.Inequality` into a Kleisli function.
   compare : (Ord t, Ord x, Number x, Divisible x, Action m) => (Key -> t -> m x) -> Inequality f t x -> Kleisli m t Bool
+  -- | The functor map operation _and_ also map any parametrs to keys.
+  -- For example, could map the param "spot" to an ISIN code "GB123456789".
+  --
+  -- @ mapParams identity = fmap
+  --
+  mapParams :  (Param -> Key)
+            -> (Param -> Decimal)
+            -> f t Param -> f t Decimal

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -39,3 +39,7 @@ class Interpret f where
   mapParams :  (Param -> Key)
             -> (Param -> Decimal)
             -> f t Param -> f t Decimal
+
+  -- | Contramap on the time parameter.
+  cmapTime : (t -> i) --TODO: fuse this with mapParams
+           -> f i x -> f t x

--- a/daml/ContingentClaims/Observable.daml
+++ b/daml/ContingentClaims/Observable.daml
@@ -36,10 +36,7 @@ class Interpret f where
   --
   -- @ mapParams identity = fmap
   --
-  mapParams :  (Param -> Key)
+  mapParams : (t -> i)
+            -> (Param -> Key)
             -> (Param -> Decimal)
-            -> f t Param -> f t Decimal
-
-  -- | Contramap on the time parameter.
-  cmapTime : (t -> i) --TODO: fuse this with mapParams
-           -> f i x -> f t x
+            -> f i Param -> f t Decimal

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -10,7 +10,8 @@ module ContingentClaims.ObservableFunctions where
 -- TODO: rename this module to something more appropriate
 
 import Daml.Control.Arrow (Arrow, arr)
-import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, undefined, Text, const, (<=))
+import Daml.Data.Functor.Contravariant
+import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, undefined, Text, const, (<=), (.))
 import Prelude qualified ((+), negate, (*), (^), (/), pure, aunit, munit)
 import ContingentClaims.Observable
 
@@ -38,3 +39,4 @@ instance Interpret (->) where
   compare _ (TimeGte t) = arr (>= t)
   compare _ (Lte (f, f')) = arr (liftA2 (<=) f f')
   mapParams _ = fmap -- There is no special observation op for functions - just use `lift`.
+  cmapTime f = getOp . contramap f . Op

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -10,8 +10,9 @@ module ContingentClaims.ObservableFunctions where
 -- TODO: rename this module to something more appropriate
 
 import Daml.Control.Category (Category, id)
-import Prelude (Applicative, Additive, Multiplicative, Divisible, Ord, aunit, munit, liftA2)
-import Prelude qualified ((+),negate,(*),(/),(<=),(==),pure)
+import Daml.Control.Arrow (Arrow, arr)
+import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, undefined, Text, const)
+import Prelude qualified ((+), negate, (*), (^), (/), pure, aunit, munit)
 import ContingentClaims.Observable
 
 -- Default instances for applicative functors
@@ -19,22 +20,19 @@ import ContingentClaims.Observable
 instance forall f t . Category f => TimeF f t where 
   time = id
 
-instance forall f t a . Applicative (f t) => PointF f t a where
+instance forall f t . (Arrow f, Applicative (f t)) => PointF f t Text where
   pure = Prelude.pure
+  observe key = arr (const key)
 
-instance forall f t a . (Additive a, Multiplicative a, Divisible a, Applicative (f t)) => RingF f t a where
-  zero = Prelude.pure aunit
-  one = Prelude.pure munit
+instance (Additive a, Applicative (f t)) => Additive (f t a) where
+  aunit = Prelude.pure Prelude.aunit
   (+) = liftA2 (Prelude.+)
-  negate = fmap (Prelude.negate)
+  negate = fmap Prelude.negate
+
+instance (Multiplicative a, Applicative (f t)) => Multiplicative (f t a) where
+  munit = Prelude.pure Prelude.munit
   (*) = liftA2 (Prelude.*)
+  (^) = undefined
+
+instance (Divisible a, Applicative (f t)) => Divisible (f t a) where
   (/) = liftA2 (Prelude./)
-
-instance forall f t a . (Ord a, Applicative (f t)) => InequalityF f t a where
-  (<=) = liftA2 (Prelude.<=)
-  (==) = liftA2 (Prelude.==)
-
-{-
-instance forall f t . (Applicative (f t)) => LogicF (f t) where
-  (&&) = liftA2 (Prelude.&&)
--}

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -10,7 +10,7 @@ module ContingentClaims.ObservableFunctions where
 -- TODO: rename this module to something more appropriate
 
 import Daml.Control.Arrow (Arrow, arr)
-import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, undefined, Text, const)
+import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, undefined, Text, const, (<=))
 import Prelude qualified ((+), negate, (*), (^), (/), pure, aunit, munit)
 import ContingentClaims.Observable
 
@@ -32,3 +32,8 @@ instance (Multiplicative a, Applicative (f t)) => Multiplicative (f t a) where
 
 instance (Divisible a, Applicative (f t)) => Divisible (f t a) where
   (/) = liftA2 (Prelude./)
+
+instance Interpret (->) where
+  eval _ f = arr f
+  compare _ (TimeLte t) = arr (<= t)
+  compare _ (Lte (f, f')) = arr (liftA2 (<=) f f')

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -11,8 +11,8 @@ module ContingentClaims.ObservableFunctions where
 
 import Daml.Control.Arrow (Arrow, arr)
 import Daml.Data.Functor.Contravariant
-import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, Text, const, (<=), (.))
-import Prelude qualified ((+), negate, (*), (^), (/), pure, aunit, munit)
+import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, Text, const, (.))
+import Prelude qualified ((+), negate, (*), (^), (/), pure, aunit, munit, (<=))
 import ContingentClaims.Observable
 
 -- Default instances for applicative functors
@@ -37,5 +37,5 @@ instance (Divisible a, Applicative (f t)) => Divisible (f t a) where
 instance Interpret (->) where
   eval _ f = arr f
   compare _ (TimeGte t) = arr (>= t)
-  compare _ (Lte (f, f')) = arr (liftA2 (<=) f f')
+  compare _ (Lte (f, f')) = arr (liftA2 (Prelude.<=) f f')
   mapParams g _ f = getOp . contramap g . Op . fmap f -- There is no special `observe` op for functions - just use `lift`.

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -9,16 +9,12 @@ module ContingentClaims.ObservableFunctions where
 
 -- TODO: rename this module to something more appropriate
 
-import Daml.Control.Category (Category, id)
 import Daml.Control.Arrow (Arrow, arr)
 import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, undefined, Text, const)
 import Prelude qualified ((+), negate, (*), (^), (/), pure, aunit, munit)
 import ContingentClaims.Observable
 
 -- Default instances for applicative functors
-
-instance forall f t . Category f => TimeF f t where 
-  time = id
 
 instance forall f t . (Arrow f, Applicative (f t)) => PointF f t Text where
   pure = Prelude.pure

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -38,5 +38,4 @@ instance Interpret (->) where
   eval _ f = arr f
   compare _ (TimeGte t) = arr (>= t)
   compare _ (Lte (f, f')) = arr (liftA2 (<=) f f')
-  mapParams _ = fmap -- There is no special observation op for functions - just use `lift`.
-  cmapTime f = getOp . contramap f . Op
+  mapParams g _ f = getOp . contramap g . Op . fmap f -- There is no special `observe` op for functions - just use `lift`.

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -35,5 +35,5 @@ instance (Divisible a, Applicative (f t)) => Divisible (f t a) where
 
 instance Interpret (->) where
   eval _ f = arr f
-  compare _ (TimeLte t) = arr (<= t)
+  compare _ (TimeGte t) = arr (>= t)
   compare _ (Lte (f, f')) = arr (liftA2 (<=) f f')

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -37,3 +37,4 @@ instance Interpret (->) where
   eval _ f = arr f
   compare _ (TimeGte t) = arr (>= t)
   compare _ (Lte (f, f')) = arr (liftA2 (<=) f f')
+  mapParams _ = fmap -- There is no special observation op for functions - just use `lift`.

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -16,7 +16,7 @@ import ContingentClaims.Observable
 
 -- Default instances for applicative functors
 
-instance forall f t . (Arrow f, Applicative (f t)) => PointF f t Text where
+instance forall f t . (Arrow f, Applicative (f t)) => Point f t Text where
   pure = Prelude.pure
   observe key = arr (const key)
 

--- a/daml/ContingentClaims/ObservableFunctions.daml
+++ b/daml/ContingentClaims/ObservableFunctions.daml
@@ -11,7 +11,7 @@ module ContingentClaims.ObservableFunctions where
 
 import Daml.Control.Arrow (Arrow, arr)
 import Daml.Data.Functor.Contravariant
-import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, undefined, Text, const, (<=), (.))
+import Prelude (Applicative, Additive, Multiplicative, Divisible, liftA2, Text, const, (<=), (.))
 import Prelude qualified ((+), negate, (*), (^), (/), pure, aunit, munit)
 import ContingentClaims.Observable
 
@@ -29,7 +29,7 @@ instance (Additive a, Applicative (f t)) => Additive (f t a) where
 instance (Multiplicative a, Applicative (f t)) => Multiplicative (f t a) where
   munit = Prelude.pure Prelude.munit
   (*) = liftA2 (Prelude.*)
-  (^) = undefined
+  x ^ i = fmap (Prelude.^ i) x
 
 instance (Divisible a, Applicative (f t)) => Divisible (f t a) where
   (/) = liftA2 (Prelude./)

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -57,11 +57,11 @@ instance Corecursive (Observation t x) (ObservationF t x) where
   embed (MulF (x, x') ) = Mul (x, x')
   embed (DivF (x, x') ) = Div (x, x')
 
-instance O.PointF Observation t t where
+instance O.Point Observation t t where
   pure = Const
   observe = Observe
 
-instance O.PointF Observation t Decimal where
+instance O.Point Observation t Decimal where
   pure = Const
   observe = Observe
 

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -81,10 +81,20 @@ instance Divisible (Observation t Decimal) where
   (/) = curry Div
 
 instance Foldable (ObservationF t x) where
-  foldr f seed (AddF (x, x')) = f x $ f x' seed
+  foldr f seed (ConstF _) = seed
+  foldr f seed (ObserveF key) = seed
+  foldr f seed (NegF b) = f b seed
+  foldr f seed (AddF (b, b')) = f b $ f b' seed
+  foldr f seed (MulF (b, b')) = f b $ f b' seed
+  foldr f seed (DivF (b, b')) = f b $ f b' seed
 
 instance Traversable (ObservationF t x) where
+  sequence (ConstF x) = pure $ ConstF x
+  sequence (ObserveF key) = pure $ ObserveF key
+  sequence (NegF m) = NegF <$> m
   sequence (AddF (m, m')) = curry AddF <$> m <*> m'
+  sequence (MulF (m, m')) = curry MulF <$> m <*> m'
+  sequence (DivF (m, m')) = curry DivF <$> m <*> m'
 
 instance O.Interpret Observation where
   eval doObserve = cataM \case
@@ -95,4 +105,4 @@ instance O.Interpret Observation where
     MulF (x, x') -> pure $ x * x'
     DivF (x, x') -> pure $ x / x'
   compare doObserve (O.Lte (f, f')) = liftA2 (<=) (O.eval doObserve f) (O.eval doObserve f')
-  compare _ (O.TimeLte t) = arr (<= t)
+  compare _ (O.TimeGte t) = arr (>= t)

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -117,19 +117,10 @@ instance O.Interpret Observation where
     DivF (b, b') -> Div (b, b')
 
   -- a no-op, but needed to infer the new type variable `t`.
-  cmapTime _ (Const x) = Const x 
-  cmapTime _ (Observe x) = Observe x 
-  cmapTime dummy (Add (b, b')) = Add (O.cmapTime dummy b, O.cmapTime dummy b')
-  cmapTime dummy (Neg b) = Neg (O.cmapTime dummy b)
-  cmapTime dummy (Mul (b, b')) = Mul (O.cmapTime dummy b, O.cmapTime dummy b')
-  cmapTime dummy (Div (b, b')) = Div (O.cmapTime dummy b, O.cmapTime dummy b')
-  
-
-
-{-
-    Observe k -> ObserveF k
-    Add (b, b') -> AddF (b, b')
-    Neg b -> NegF b
-    Mul (b, b') -> MulF (b, b')
-    Div (b, b') -> DivF (b, b')
--}
+  cmapTime _ = cata \case
+    ConstF x -> Const x
+    ObserveF k -> Observe k
+    AddF (b, b') -> Add (b, b')
+    NegF b -> Neg b
+    MulF (b, b') -> Mul (b, b')
+    DivF (b, b') -> Div (b, b')

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -108,18 +108,9 @@ instance O.Interpret Observation where
   compare doObserve (O.Lte (f, f')) = liftA2 (<=) (O.eval doObserve f) (O.eval doObserve f')
   compare _ (O.TimeGte t) = arr (>= t)
 
-  mapParams g f = cata \case
+  mapParams _ g f = cata \case
     ConstF x -> Const (f x)
     ObserveF key -> Observe (g key)
-    AddF (b, b') -> Add (b, b')
-    NegF b -> Neg b
-    MulF (b, b') -> Mul (b, b')
-    DivF (b, b') -> Div (b, b')
-
-  -- a no-op, but needed to infer the new type variable `t`.
-  cmapTime _ = cata \case
-    ConstF x -> Const x
-    ObserveF k -> Observe k
     AddF (b, b') -> Add (b, b')
     NegF b -> Neg b
     MulF (b, b') -> Mul (b, b')

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -115,3 +115,12 @@ instance O.Interpret Observation where
     NegF b -> Neg b
     MulF (b, b') -> Mul (b, b')
     DivF (b, b') -> Div (b, b')
+
+  -- a no-op, but needed to infer the new type variable
+  cmapTime _ = ana \case
+    Const x -> ConstF x
+    Observe k -> ObserveF k
+    Add (b, b') -> AddF (b, b')
+    Neg b -> NegF b
+    Mul (b, b') -> MulF (b, b')
+    Div (b, b') -> DivF (b, b')

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -12,7 +12,7 @@ module ContingentClaims.Observation (
 import ContingentClaims.Observable qualified as O
 import ContingentClaims.Recursion (cataM)
 import Daml.Control.Arrow (Kleisli(..), arr)
-import Daml.Control.Recursion (Recursive(..), Corecursive(..))
+import Daml.Control.Recursion (Recursive(..), Corecursive(..), project, embed)
 import DA.Traversable (Traversable(..))
 import DA.Foldable (Foldable(..))
 import Prelude hiding (key, (.))
@@ -104,5 +104,14 @@ instance O.Interpret Observation where
     NegF x -> pure $ negate x
     MulF (x, x') -> pure $ x * x'
     DivF (x, x') -> pure $ x / x'
+
   compare doObserve (O.Lte (f, f')) = liftA2 (<=) (O.eval doObserve f) (O.eval doObserve f')
   compare _ (O.TimeGte t) = arr (>= t)
+
+  mapParams g f = cata \case
+    ConstF x -> Const (f x)
+    ObserveF key -> Observe (g key)
+    AddF (b, b') -> Add (b, b')
+    NegF b -> Neg b
+    MulF (b, b') -> Mul (b, b')
+    DivF (b, b') -> Div (b, b')

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -20,7 +20,7 @@ import Prelude hiding (key, (.))
 type T = Observation
 
 -- | Concrete implementation of `Observable`, which can be serialized.
--- Conceptually it's helpfult to think of this as the type `t -> x`, or `t -> Update x`.
+-- Conceptually it's helpful to think of this as the type `t -> x`, or `t -> Update x`.
 data Observation t x
   = Const with value: x 
     -- ^ A named constant
@@ -74,6 +74,8 @@ instance Multiplicative (Observation t Decimal) where
   munit = Const 0.0
   (*) = curry Mul
   (^) = undefined
+
+instance Number (Observation t Decimal) where
 
 instance Divisible (Observation t Decimal) where
   (/) = curry Div

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -7,140 +7,103 @@
 
 module ContingentClaims.Observation (
     Observation(..)
-  , observe
-  , expiry
   , eval
-  , HasFixings(..)
-  , Key
 ) where
 
 import ContingentClaims.Observable qualified as O
-import Daml.Control.Arrow (Kleisli(..))
-import Daml.Control.Category
+import ContingentClaims.Recursion (cataM)
+import Daml.Control.Arrow (Kleisli(..), arr)
+import Daml.Control.Recursion (Recursive(..), Corecursive(..))
+import DA.Traversable (Traversable(..))
+import DA.Foldable (Foldable(..))
+import Prelude hiding (key, (.))
 
-type Key = Text
 type T = Observation
 
 -- | Concrete implementation of `Observable`, which can be serialized.
-data Observation t a
-  = DecimalConst Decimal
-  | DecimalObs Key
-  | DecimalLte (Observation t Decimal, Observation t Decimal)
-  | DecimalEqu (Observation t Decimal, Observation t Decimal)
-  | DecimalAdd (Observation t Decimal, Observation t Decimal)
-  | DecimalNeg (Observation t Decimal)
-  | DecimalMul (Observation t Decimal, Observation t Decimal)
-  | DecimalDiv (Observation t Decimal, Observation t Decimal)
-  | BoolConst Bool
-  | DateIdentity
-  | DateConst t
-  | DateLte (Observation t t, Observation t t)
-  | DateEqu (Observation t t, Observation t t)
+-- Conceptually it's helpfult to think of this as the type `t -> x`, or `t -> Update x`.
+data Observation t x
+  = Const with value: x 
+    -- ^ A named constant
+  | Observe with key: O.Key 
+    -- ^ A named parameter
+  | Identity 
+    -- ^ The identity function, `t -> t`; useful for time comparisons.
+    -- e.g. `Inequality(Identity, Const "tomorrow" (date _))` equates to `time <= tomorrow`
+  | Add (Observation t x, Observation t x)
+  | Neg (Observation t x)
+  | Mul (Observation t x, Observation t x)
+  | Div (Observation t x, Observation t x)
   deriving (Eq, Show)
 
-{- TODO: The algebra in it's current form is partial, so we can't implement (Co)recursive instance.
-data ObservationF t a x
-  = DecimalConstF Decimal
-  | DecimalObsF Key
-  | DecimalLteF (x, x)
-  | DecimalEquF (x, x)
-  | DecimalAddF (x, x)
-  | DecimalNegF x
-  | DecimalMulF (x, x)
-  | DecimalDivF (x, x)
-  | BoolConstF Bool
-  | DateIdentityF
-  | DateConstF t
-  | DateLteF (x, x)
-  | DateEquF (x, x)
+data ObservationF t x b
+  = ConstF with value: x 
+  | ObserveF with key: O.Key 
+  | IdentityF
+  | AddF (b, b)
+  | NegF (b)
+  | MulF (b, b)
+  | DivF (b, b)
   deriving (Eq, Show, Functor)
--}
 
-observe : Text -> Observation t a
-observe = DecimalObs
+instance Recursive (Observation t x) (ObservationF t x) where
+  project (Const value) = ConstF value
+  project (Observe key) = ObserveF key
+  project Identity = IdentityF
+  project (Add (x, x')) = AddF (x, x')
+  project (Neg x) = NegF x
+  project (Mul (x, x') ) = MulF (x, x')
+  project (Div (x, x') ) = DivF (x, x')
+
+instance Corecursive (Observation t x) (ObservationF t x) where
+  embed (ConstF value) = Const value
+  embed (ObserveF key) = Observe key
+  embed IdentityF = Identity
+  embed (AddF (x, x')) = Add (x, x)
+  embed (NegF x) = Neg x
+  embed (MulF (x, x') ) = Mul (x, x')
+  embed (DivF (x, x') ) = Div (x, x')
 
 instance O.TimeF Observation t where
-  time = DateIdentity
+  time = Identity
 
 instance O.PointF Observation t t where
-  pure = DateConst
-
-instance O.InequalityF Observation t t where
-  (<=) = curry DateLte
-  (==) = curry DateEqu
+  pure = Const
+  observe = Observe
 
 instance O.PointF Observation t Decimal where
-  pure = DecimalConst
+  pure = Const
+  observe = Observe
 
-instance O.InequalityF Observation t Decimal where
-  (<=) = curry DecimalLte
-  (==) = curry DecimalEqu
+instance Additive (Observation t Decimal) where
+  aunit = Const 1.0
+  (+) = curry Add
+  negate = Neg
 
-instance O.RingF Observation t Decimal where
-  zero = DecimalConst 0.0
-  one = DecimalConst 1.0
-  (+) = curry DecimalAdd
-  negate = DecimalNeg
-  (*) = curry DecimalMul
-  (/) = curry DecimalDiv
+instance Multiplicative (Observation t Decimal) where
+  munit = Const 0.0
+  (*) = curry Mul
+  (^) = undefined
 
---TODO: move expiry into the 'Interpret' typeclass
--- Derive the expiry date from a boolean expression
-expiry : Observation t Bool -> Optional t
-expiry (DateLte (DateIdentity, o)) = expiryDt o
-expiry (DateEqu (DateIdentity, o)) = expiryDt o
-expiry o = error "Error in  expression structure"
+instance Divisible (Observation t Decimal) where
+  (/) = curry Div
 
--- Helper function
-expiryDt (DateLte (DateIdentity, o)) = expiryDt o
-expiryDt (DateEqu (DateIdentity, o)) = expiryDt o
-expiryDt DateIdentity = None
-expiryDt (DateConst t) = Some t
-expiryDt _ = error "Error in  expression structure"
+instance Foldable (ObservationF t x) where
+  foldr f seed (AddF (x, x')) = f x $ f x' seed
 
-class Interpret t a where
-  eval : Monad m => (Key -> t -> m Decimal) -> Observation t a -> Kleisli m t a
+instance Traversable (ObservationF t x) where
+  sequence (AddF (m, m')) = curry AddF <$> m <*> m'
 
-instance Ord t => Interpret t Bool where
-  eval _ (BoolConst b) = pure b
-  eval spot (DecimalLte (d, d')) = liftA2 (<=) (eval spot d) (eval spot d')
-  eval spot (DecimalEqu (d, d')) = liftA2 (==) (eval spot d) (eval spot d')
-  eval spot (DateLte (d, d')) = liftA2 (<=) (eval spot d) (eval spot d')
-  eval spot (DateEqu (d, d')) = liftA2 (==) (eval spot d) (eval spot d')
-  eval _ _ = error "eval: Interpret Bool"
-
-instance Interpret t t where
-  eval _ (DateConst t) = pure t
-  eval _ DateIdentity = id
-  eval _ _ = error "eval: Interpret Date"
-
-instance Interpret t Decimal where
-  eval _ (DecimalConst d) = pure d
-  eval spot (DecimalObs key) = Kleisli $ spot key
-  eval spot (DecimalAdd (x, x')) = liftA2 (+) (eval spot x) (eval spot x')
-  eval spot (DecimalNeg x) = fmap (\x -> (- x)) (eval spot x)
-  eval spot (DecimalMul (x, x')) = liftA2 (*) (eval spot x) (eval spot x')
-  eval spot (DecimalDiv (x, x')) = liftA2 (/) (eval spot x) (eval spot x')
-  eval _ _ = error "eval: Interpret Decimal"
-
-class HasFixings t a where
-  fixings : Observation t a -> [t]
-    -- ^ Given an observation, return a list of fixing dates.
-
-instance HasFixings t Bool where
-  fixings (DateEqu (o, o')) = fixings o ++ fixings o'
-  fixings (DateLte (o, o')) = error "fixings: unimplemented DateLte"
-  fixings _ = error "fixings: unimplemented"
-
-instance HasFixings t t where
-  fixings (DateConst d) = [d]
-  fixings DateIdentity = []
-  fixings _ = error "fixings: illegal argument"
-
-instance HasFixings t Decimal where
-  fixings (DecimalObs _) = []
-  fixings (DecimalAdd _) = []
-  fixings (DecimalNeg _) = []
-  fixings (DecimalMul _) = []
-  fixings (DecimalDiv _) = []
-  fixings _ = error "fixings: illegal argument"
+eval : (Divisible x, Number x, Monad m) 
+     => (t -> x)
+     -> (O.Key -> t -> m x) 
+     -> Observation t x 
+     -> Kleisli m t x
+eval yoneda doObserve = cataM \case
+  ConstF x -> pure x
+  ObserveF key -> Kleisli (doObserve key)
+  AddF (x, x') -> pure $ x Prelude.+ x'
+  NegF x -> pure $ negate x
+  MulF (x, x') -> pure $ x * x'
+  DivF (x, x') -> pure $ x / x'
+  IdentityF -> arr yoneda

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -61,23 +61,23 @@ instance O.Point Observation t t where
   pure = Const
   observe = Observe
 
-instance O.Point Observation t Decimal where
+instance O.Point Observation t x where
   pure = Const
   observe = Observe
 
-instance Additive (Observation t Decimal) where
-  aunit = Const 1.0
+instance Additive x => Additive (Observation t x) where
+  aunit = Const aunit
   (+) = curry Add
   negate = Neg
 
-instance Multiplicative (Observation t Decimal) where
-  munit = Const 0.0
+instance Multiplicative x => Multiplicative (Observation t x) where
+  munit = Const munit
   (*) = curry Mul
   (^) = undefined
 
-instance Number (Observation t Decimal) where
+instance (Additive x, Multiplicative x) => Number (Observation t x) where
 
-instance Divisible (Observation t Decimal) where
+instance Multiplicative x => Divisible (Observation t x) where
   (/) = curry Div
 
 instance Foldable (ObservationF t x) where
@@ -116,7 +116,7 @@ instance O.Interpret Observation where
     MulF (b, b') -> Mul (b, b')
     DivF (b, b') -> Div (b, b')
 
-  -- a no-op, but needed to infer the new type variable
+  -- a no-op, but needed to infer the new type variable `t`.
   cmapTime _ = ana \case
     Const x -> ConstF x
     Observe k -> ObserveF k

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -8,6 +8,7 @@
 module ContingentClaims.Observation (
     Observation(..)
   , eval
+  , evalInequality --FIXME, generalise and move to Observable
 ) where
 
 import ContingentClaims.Observable qualified as O
@@ -27,9 +28,6 @@ data Observation t x
     -- ^ A named constant
   | Observe with key: O.Key 
     -- ^ A named parameter
-  | Identity 
-    -- ^ The identity function, `t -> t`; useful for time comparisons.
-    -- e.g. `Inequality(Identity, Const "tomorrow" (date _))` equates to `time <= tomorrow`
   | Add (Observation t x, Observation t x)
   | Neg (Observation t x)
   | Mul (Observation t x, Observation t x)
@@ -39,7 +37,6 @@ data Observation t x
 data ObservationF t x b
   = ConstF with value: x 
   | ObserveF with key: O.Key 
-  | IdentityF
   | AddF (b, b)
   | NegF (b)
   | MulF (b, b)
@@ -49,7 +46,6 @@ data ObservationF t x b
 instance Recursive (Observation t x) (ObservationF t x) where
   project (Const value) = ConstF value
   project (Observe key) = ObserveF key
-  project Identity = IdentityF
   project (Add (x, x')) = AddF (x, x')
   project (Neg x) = NegF x
   project (Mul (x, x') ) = MulF (x, x')
@@ -58,14 +54,10 @@ instance Recursive (Observation t x) (ObservationF t x) where
 instance Corecursive (Observation t x) (ObservationF t x) where
   embed (ConstF value) = Const value
   embed (ObserveF key) = Observe key
-  embed IdentityF = Identity
   embed (AddF (x, x')) = Add (x, x)
   embed (NegF x) = Neg x
   embed (MulF (x, x') ) = Mul (x, x')
   embed (DivF (x, x') ) = Div (x, x')
-
-instance O.TimeF Observation t where
-  time = Identity
 
 instance O.PointF Observation t t where
   pure = Const
@@ -95,15 +87,19 @@ instance Traversable (ObservationF t x) where
   sequence (AddF (m, m')) = curry AddF <$> m <*> m'
 
 eval : (Divisible x, Number x, Monad m) 
-     => (t -> x)
-     -> (O.Key -> t -> m x) 
+     => (O.Key -> t -> m x) 
      -> Observation t x 
      -> Kleisli m t x
-eval yoneda doObserve = cataM \case
+eval doObserve = cataM \case
   ConstF x -> pure x
   ObserveF key -> Kleisli (doObserve key)
   AddF (x, x') -> pure $ x Prelude.+ x'
   NegF x -> pure $ negate x
   MulF (x, x') -> pure $ x * x'
   DivF (x, x') -> pure $ x / x'
-  IdentityF -> arr yoneda
+
+
+-- FIXME `eval` needs to go into a typeclass, so that it also works for pure functions `(->)`
+evalInequality : (Ord t, Ord x, Divisible x, Number x, Monad m) => (O.Key -> t -> m x) -> O.Inequality Observation t x -> Kleisli m t Bool
+evalInequality doObserve (O.Lte (f, f')) = liftA2 (<=) (eval doObserve f) (eval doObserve f')
+evalInequality _ (O.TimeLte t) = arr (<= t)

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -73,7 +73,10 @@ instance Additive x => Additive (Observation t x) where
 instance Multiplicative x => Multiplicative (Observation t x) where
   munit = Const munit
   (*) = curry Mul
-  (^) = undefined
+  x ^ 0 = munit
+  x ^ 1 = x
+  x ^ 2 = x * x
+  x ^ _ = error "Observation: power operator < 0 and > 2 not implemented"
 
 instance (Additive x, Multiplicative x) => Number (Observation t x) where
 

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -7,8 +7,6 @@
 
 module ContingentClaims.Observation (
     Observation(..)
-  , eval
-  , evalInequality --FIXME, generalise and move to Observable
 ) where
 
 import ContingentClaims.Observable qualified as O
@@ -86,20 +84,13 @@ instance Foldable (ObservationF t x) where
 instance Traversable (ObservationF t x) where
   sequence (AddF (m, m')) = curry AddF <$> m <*> m'
 
-eval : (Divisible x, Number x, Monad m) 
-     => (O.Key -> t -> m x) 
-     -> Observation t x 
-     -> Kleisli m t x
-eval doObserve = cataM \case
-  ConstF x -> pure x
-  ObserveF key -> Kleisli (doObserve key)
-  AddF (x, x') -> pure $ x Prelude.+ x'
-  NegF x -> pure $ negate x
-  MulF (x, x') -> pure $ x * x'
-  DivF (x, x') -> pure $ x / x'
-
-
--- FIXME `eval` needs to go into a typeclass, so that it also works for pure functions `(->)`
-evalInequality : (Ord t, Ord x, Divisible x, Number x, Monad m) => (O.Key -> t -> m x) -> O.Inequality Observation t x -> Kleisli m t Bool
-evalInequality doObserve (O.Lte (f, f')) = liftA2 (<=) (eval doObserve f) (eval doObserve f')
-evalInequality _ (O.TimeLte t) = arr (<= t)
+instance O.Interpret Observation where
+  eval doObserve = cataM \case
+    ConstF x -> pure x
+    ObserveF key -> Kleisli (doObserve key)
+    AddF (x, x') -> pure $ x Prelude.+ x'
+    NegF x -> pure $ negate x
+    MulF (x, x') -> pure $ x * x'
+    DivF (x, x') -> pure $ x / x'
+  compare doObserve (O.Lte (f, f')) = liftA2 (<=) (O.eval doObserve f) (O.eval doObserve f')
+  compare _ (O.TimeLte t) = arr (<= t)

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -10,7 +10,7 @@ module ContingentClaims.Observation (
 ) where
 
 import ContingentClaims.Observable qualified as O
-import ContingentClaims.Recursion (cataM)
+import ContingentClaims.Util.Recursion (cataM)
 import Daml.Control.Arrow (Kleisli(..), arr)
 import Daml.Control.Recursion (Recursive(..), Corecursive(..), project, embed)
 import DA.Traversable (Traversable(..))

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -117,10 +117,19 @@ instance O.Interpret Observation where
     DivF (b, b') -> Div (b, b')
 
   -- a no-op, but needed to infer the new type variable `t`.
-  cmapTime _ = ana \case
-    Const x -> ConstF x
+  cmapTime _ (Const x) = Const x 
+  cmapTime _ (Observe x) = Observe x 
+  cmapTime dummy (Add (b, b')) = Add (O.cmapTime dummy b, O.cmapTime dummy b')
+  cmapTime dummy (Neg b) = Neg (O.cmapTime dummy b)
+  cmapTime dummy (Mul (b, b')) = Mul (O.cmapTime dummy b, O.cmapTime dummy b')
+  cmapTime dummy (Div (b, b')) = Div (O.cmapTime dummy b, O.cmapTime dummy b')
+  
+
+
+{-
     Observe k -> ObserveF k
     Add (b, b') -> AddF (b, b')
     Neg b -> NegF b
     Mul (b, b') -> MulF (b, b')
     Div (b, b') -> DivF (b, b')
+-}

--- a/daml/ContingentClaims/Recursion.daml
+++ b/daml/ContingentClaims/Recursion.daml
@@ -42,10 +42,7 @@ apoM f a = (fmap embed <<< (>>= (mapA (pure ||| apoM f))) <<< f) a
 
 -- | Specialised lazy re-fold, used by `lifecycle`.
 apoCataM : (Monad m, Traversable f, Corecursive b f) => (f b -> b) -> (a -> m (f (Either b a))) -> a -> m b
-apoCataM g f a = _apoCataM g f a 
-
--- | HIDE
-_apoCataM g f a = (fmap g <<< (>>= (mapA (pure ||| apoCataM g f))) <<< f) a
+apoCataM g f a = (fmap g <<< (>>= (mapA (pure ||| apoCataM g f))) <<< f) a
 
 -- Functor unzip
 funzip : Functor f => f (a, b) -> (f a, f b)

--- a/daml/ContingentClaims/Recursion.daml
+++ b/daml/ContingentClaims/Recursion.daml
@@ -1,0 +1,73 @@
+--
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+{-# OPTIONS -Wno-deprecations #-} -- To supress 'Monad' warnings
+
+module ContingentClaims.Recursion (
+    cataM
+  , paraM
+  , anaM
+  , apoM
+  , apoCataM
+  , funzip
+  , synthesize
+  , inherit
+  , subTreeSize'
+) where
+
+import Prelude hiding (sequence, mapA, sum)
+import DA.Traversable (Traversable, sequence, mapA)
+import Daml.Control.Recursion (Recursive(..), Corecursive(..), Cofree(..))
+import DA.Foldable (Foldable, sum)
+import Daml.Control.Arrow ((&&&), (|||), (>>>), (<<<), Kleisli(..))
+
+-- The morphisms ending in 'M' are monadic variants, allowing to interleave e.g. `Update` or `Script`.
+-- `cataM` After Tim Williams' talk, https://www.youtube.com/watch?v=Zw9KeP3OzpU.
+
+-- TODO: the two folds can probably be simplified with Traverse.mapA too.
+cataM : (Monad m, Traversable f, Recursive b f) => (f a -> m a) -> b -> m a
+cataM f b = (project >>> fmap (cataM f) >>> (>>= f) . sequence) b
+
+paraM : (Monad m, Traversable f, Recursive b f) => (f (b, a) -> m a) -> b -> m a
+paraM f b = (project >>> fmap (runKleisli $ Kleisli pure &&& Kleisli (paraM f)) >>> (>>= f) . sequence) b
+
+-- FIXME : I think the algebra should be a -> m (f a)
+anaM : (Monad m, Traversable f, Corecursive b f) => (a -> f (m a)) -> a -> m b
+anaM f a = (fmap embed <<< mapA (>>= anaM f) <<< f) a
+
+apoM : (Monad m, Traversable f, Corecursive b f) => (a -> m (f (Either b a))) -> a -> m b
+apoM f a = (fmap embed <<< (>>= (mapA (pure ||| apoM f))) <<< f) a
+
+-- | Specialised lazy re-fold, used by `lifecycle`.
+apoCataM : (Monad m, Traversable f, Corecursive b f) => (f b -> b) -> (a -> m (f (Either b a))) -> a -> m b
+apoCataM g f a = _apoCataM g f a 
+
+-- | HIDE
+_apoCataM g f a = (fmap g <<< (>>= (mapA (pure ||| apoCataM g f))) <<< f) a
+
+-- Functor unzip
+funzip : Functor f => f (a, b) -> (f a, f b)
+funzip = fmap fst &&& fmap snd
+
+-- Annotate the tree bottom-up
+synthesize : (Functor f, Recursive b f) => (f attr -> attr) -> b -> Cofree f attr
+synthesize f = cata algebra where
+  -- alg : f (Cofree f a) -> Cofree f a
+  algebra = uncurry Cofree . (f . fmap (.attribute) &&& identity)
+
+-- Annotate the tree top-down
+inherit : (Functor f, Corecursive b f, Recursive b f) => (b -> attr -> attr) -> attr -> b -> Cofree f attr
+inherit g seed b = para algebra b seed where
+  -- f (b, attr -> Cofree f attr) -> attr -> Cofree f attr
+  algebra gbg attr = Cofree attr' f' where
+    (fb, ff) = funzip gbg
+    attr' = g (embed fb) attr
+    f' = fmap ($ attr') ff
+
+-- Returns a tree with each node annotated with the # of nodes below it + 1
+subTreeSize' : Foldable f => f Int -> Int
+subTreeSize' c = 1 + sum c
+
+

--- a/daml/ContingentClaims/Util.daml
+++ b/daml/ContingentClaims/Util.daml
@@ -8,16 +8,12 @@
 module ContingentClaims.Util (
     enumerateFrom
   , enum'
-{-
-  , fixings
-  , fixings'
--}
   , pruneZeros
   , pruneZeros'
 ) where
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
-import ContingentClaims.Recursion (synthesize, subTreeSize')
+import ContingentClaims.Util.Recursion (synthesize, subTreeSize')
 import Daml.Control.Recursion
 import Prelude hiding (sum, sequence, mapA)
 
@@ -35,16 +31,6 @@ enum' (i, Cofree _ (CondF p f@(Cofree depth _) f')) = CofreeF i (CondF p (succ i
 -- Enumerate each node in the tree, starting from from 'zero'
 enumerateFrom : Int -> Claim f t x a -> Cofree (ClaimF f t x a) Int
 enumerateFrom zero = ana enum' . (zero, ) . synthesize subTreeSize'
-
-{-
-fixings : Claim Observation Date a -> [Date]
-fixings = cata fixings'
-
---TODO should fail if dates will never be executed
-fixings' : ClaimF Observation Date a [Date] -> [Date]
-fixings' (WhenF p ts) = O.fixings p ++ ts
-fixings' claim = fold claim
--}
 
 pruneZeros : Claim f t x a -> Claim f t x a
 pruneZeros = cata pruneZeros'

--- a/daml/ContingentClaims/Util.daml
+++ b/daml/ContingentClaims/Util.daml
@@ -8,79 +8,21 @@
 module ContingentClaims.Util (
     enumerateFrom
   , enum'
-  , cataM
-  , paraM
-  , anaM
-  , apoM
-  , apoCataM
-  , funzip
-  , synthesize
-  , inherit
-  , subTreeSize'
+{-
   , fixings
   , fixings'
+-}
   , pruneZeros
   , pruneZeros'
 ) where
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..))
-import ContingentClaims.Observation (Observation)
-import ContingentClaims.Observation qualified as O
-import DA.Foldable (Foldable, sum, fold)
-import Daml.Control.Arrow ((&&&), (|||), (>>>), (<<<), Kleisli(..))
+import ContingentClaims.Recursion (synthesize, subTreeSize')
 import Daml.Control.Recursion
 import Prelude hiding (sum, sequence, mapA)
-import DA.Traversable (Traversable, sequence, mapA)
-
--- The morphisms ending in 'M' are monadic variants, allowing to interleave e.g. `Update` or `Script`.
--- `cataM` After Tim Williams' talk, https://www.youtube.com/watch?v=Zw9KeP3OzpU.
-
--- TODO: the two folds can probably be simplified with Traverse.mapA too.
-cataM : (Monad m, Traversable f, Recursive b f) => (f a -> m a) -> b -> m a
-cataM f b = (project >>> fmap (cataM f) >>> (>>= f) . sequence) b
-
-paraM : (Monad m, Traversable f, Recursive b f) => (f (b, a) -> m a) -> b -> m a
-paraM f b = (project >>> fmap (runKleisli $ Kleisli pure &&& Kleisli (paraM f)) >>> (>>= f) . sequence) b
-
--- FIXME : I think the algebra should be a -> m (f a)
-anaM : (Monad m, Traversable f, Corecursive b f) => (a -> f (m a)) -> a -> m b
-anaM f a = (fmap embed <<< mapA (>>= anaM f) <<< f) a
-
-apoM : (Monad m, Traversable f, Corecursive b f) => (a -> m (f (Either b a))) -> a -> m b
-apoM f a = (fmap embed <<< (>>= (mapA (pure ||| apoM f))) <<< f) a
-
--- | Specialised lazy re-fold, used by `lifecycle`.
-apoCataM : (Monad m, Traversable f, Corecursive b f) => (f b -> b) -> (a -> m (f (Either b a))) -> a -> m b
-apoCataM g f a = _apoCataM g f a 
-
--- | HIDE
-_apoCataM g f a = (fmap g <<< (>>= (mapA (pure ||| apoCataM g f))) <<< f) a
-
--- Functor unzip
-funzip : Functor f => f (a, b) -> (f a, f b)
-funzip = fmap fst &&& fmap snd
-
--- Annotate the tree bottom-up
-synthesize : (Functor f, Recursive b f) => (f attr -> attr) -> b -> Cofree f attr
-synthesize f = cata algebra where
-  -- alg : f (Cofree f a) -> Cofree f a
-  algebra = uncurry Cofree . (f . fmap (.attribute) &&& identity)
-
--- Annotate the tree top-down
-inherit : (Functor f, Corecursive b f, Recursive b f) => (b -> attr -> attr) -> attr -> b -> Cofree f attr
-inherit g seed b = para algebra b seed where
-  -- f (b, attr -> Cofree f attr) -> attr -> Cofree f attr
-  algebra gbg attr = Cofree attr' f' where
-    (fb, ff) = funzip gbg
-    attr' = g (embed fb) attr
-    f' = fmap ($ attr') ff
-
--- Returns a tree with each node annotated with the # of nodes below it + 1
-subTreeSize' : Foldable f => f Int -> Int
-subTreeSize' c = 1 + sum c
 
 -- Given a tree annotated with the number of nodes in each branch, index it, depth first.
-enum' : (Int, Cofree (ClaimF f t a) Int) -> CofreeF (ClaimF f t a) Int (Int, Cofree (ClaimF f t a) Int)
+enum' : (Int, Cofree (ClaimF f t x a) Int) -> CofreeF (ClaimF f t x a) Int (Int, Cofree (ClaimF f t x a) Int)
 enum' (i, Cofree _ ZeroF) = CofreeF i ZeroF
 enum' (i, Cofree _ (OneF id)) = CofreeF i (OneF id)
 enum' (i, Cofree _ (WhenF p f)) = CofreeF i (WhenF p (succ i, f))
@@ -91,9 +33,10 @@ enum' (i, Cofree _ (OrF f@(Cofree depth _) f')) = CofreeF i (OrF (succ i, f) (su
 enum' (i, Cofree _ (CondF p f@(Cofree depth _) f')) = CofreeF i (CondF p (succ i, f) (succ (i + depth), f'))
 
 -- Enumerate each node in the tree, starting from from 'zero'
-enumerateFrom : Int -> Claim f t a -> Cofree (ClaimF f t a) Int
+enumerateFrom : Int -> Claim f t x a -> Cofree (ClaimF f t x a) Int
 enumerateFrom zero = ana enum' . (zero, ) . synthesize subTreeSize'
 
+{-
 fixings : Claim Observation Date a -> [Date]
 fixings = cata fixings'
 
@@ -101,12 +44,13 @@ fixings = cata fixings'
 fixings' : ClaimF Observation Date a [Date] -> [Date]
 fixings' (WhenF p ts) = O.fixings p ++ ts
 fixings' claim = fold claim
+-}
 
-pruneZeros : Claim f t a -> Claim f t a
+pruneZeros : Claim f t x a -> Claim f t x a
 pruneZeros = cata pruneZeros'
 
 -- | Prunes sub-trees which are `Zero` a.s.
-pruneZeros' : ClaimF f t a (Claim f t a) -> Claim f t a
+pruneZeros' : ClaimF f t x a (Claim f t x a) -> Claim f t x a
 pruneZeros' (ScaleF _ Zero) = Zero
 pruneZeros' (GiveF Zero) = Zero
 pruneZeros' (AndF Zero c) = c

--- a/daml/ContingentClaims/Util/Recursion.daml
+++ b/daml/ContingentClaims/Util/Recursion.daml
@@ -5,7 +5,7 @@
 
 {-# OPTIONS -Wno-deprecations #-} -- To supress 'Monad' warnings
 
-module ContingentClaims.Recursion (
+module ContingentClaims.Util.Recursion (
     cataM
   , paraM
   , anaM

--- a/test/daml/Test/Enumerate.daml
+++ b/test/daml/Test/Enumerate.daml
@@ -18,8 +18,8 @@ import Daml.Script
 import Prelude hiding (enumerate, length, or, and)
 import ContingentClaims.Util (enumerateFrom)
 
-type C = Claim Observation Date Text
-type F = ClaimF Observation Date Text
+type C = Claim Observation Date Decimal Text
+type F = ClaimF Observation Date Decimal Text
 
 deriving instance Show C
 deriving instance (Show a, Show (f (Cofree f a))) => Show (Cofree f a)

--- a/test/daml/Test/FinancialContract.daml
+++ b/test/daml/Test/FinancialContract.daml
@@ -16,7 +16,6 @@ type T = FinancialContract
 type Days = Int
 type ISIN = Text
 type Asset = Either Currency ISIN
-type Claims = Claim Date Asset
 
 template Quote
   with
@@ -33,7 +32,7 @@ template FinancialContract
   with
     bearer: Party
     counterparty: Party
-    claims: Claim Date Asset
+    claims: Claim Date Decimal Asset
   where
     signatory Set.fromList [bearer, counterparty]
 

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -12,7 +12,6 @@ module Test.Lifecycle where
 import ContingentClaims.Claim hiding (C, F)
 import ContingentClaims.Observable qualified as O
 import ContingentClaims.Observation (Observation)
-import ContingentClaims.Observation qualified as O
 import ContingentClaims.Lifecycle qualified as Lifecycle
 import ContingentClaims.FinancialClaim
 import DA.Assert ((===))
@@ -21,8 +20,8 @@ import Daml.Control.Recursion
 import Daml.Script
 import Prelude hiding (enumerate, length, or, and)
 
-type C = Claim Observation Date Text
-type F = ClaimF Observation Date Text
+type C = Claim Observation Date Decimal Text
+type F = ClaimF Observation Date Decimal Text
 
 deriving instance Show C
 deriving instance (Show a, Show (f (Cofree f a))) => Show (Cofree f a)
@@ -66,7 +65,7 @@ lifecycling = script do
   remaining === bond.rhs
   pending === pure (100_000.0 * 0.03, a)
 
-  let option : C = european (date 2021 Mar 9) $ Scale (O.observe "USD"  O.- O.pure 42.0) (One a)
+  let option : C = european (date 2021 Mar 9) $ Scale (O.observe "USD"  - O.pure 42.0) (One a)
       spot _ _ = pure (43.4 : Decimal)
   Lifecycle.Result{remaining, pending} <-
     Lifecycle.lifecycle spot chooseLeft option (date 2021 Mar 9)

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -11,6 +11,7 @@ module Test.Lifecycle where
 
 import ContingentClaims.Claim hiding (C, F)
 import ContingentClaims.Observable qualified as O
+import ContingentClaims.Observable (at)
 import ContingentClaims.Observation (Observation)
 import ContingentClaims.Lifecycle qualified as Lifecycle
 import ContingentClaims.FinancialClaim

--- a/test/daml/Test/Serialization.daml
+++ b/test/daml/Test/Serialization.daml
@@ -14,13 +14,13 @@ import DA.Assert
 import DA.Date (Month(..))
 import ContingentClaims.Observation (Observation)
 
-deriving instance Show (Claim Observation Date Text)
-deriving instance Eq (Claim Observation Date Text)
+deriving instance Show (Claim Observation Date Decimal Text)
+deriving instance Eq (Claim Observation Date Decimal Text)
 
 testSerialization = script do
   let fixingDates = unrollDates 2020 2025 [Jan] 15
-      bond : Claim Observation Date Text = fixed 100.0 3.0 "USD" fixingDates
-      zero : Claim Observation Date Text = Zero
+      bond : Claim Observation Date Decimal Text = fixed 100.0 3.0 "USD" fixingDates
+      zero : Claim Observation Date Decimal Text = Zero
 
   -- identity
   (deserialize . serialize $ bond) === bond

--- a/test/daml/Test/Templating.daml
+++ b/test/daml/Test/Templating.daml
@@ -1,0 +1,48 @@
+--
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+{-# LANGUAGE UndecidableInstances #-} --needed to derive cofree Show,Eq
+
+-- | This gives an example of how to 'template' claims.
+module Test.Templating where
+
+import Daml.Script
+import ContingentClaims.FinancialClaim
+import ContingentClaims.Observable qualified as O
+import ContingentClaims.Observation (Observation(..))
+import ContingentClaims.Claim
+import DA.Date
+import DA.Assert
+import DA.Optional (fromSome)
+import DA.Map qualified as Map
+
+deriving instance (Show t, Show x, Show a) => Show (Claim Observation t x a)
+deriving instance (Eq t, Eq x, Eq a) => Eq (Claim Observation t x a)
+
+instance Additive Text where
+  aunit = "0"
+  x + y = x <> "+" <> y
+  negate x = "-" <> x
+
+instance Multiplicative Text where
+  munit = "1"
+  x * y = x <> "*" <> y
+  x ^ i = x <> "^" <> show i
+
+usd = "USD"
+
+demoTemplate = script do
+  let today = date 2021 Jun 8
+      call spot strike = O.observe spot - O.pure strike
+      aTemplate = european (date 2021 Jul 15 `subDate` today) (Scale (call "s" "k") (One usd))
+
+  aTemplate === When (O.TimeGte 37) (Scale (Observe "s" - Const "k") (One usd) `Or` Zero)
+
+  let constants : Map.Map O.Param Decimal = Map.fromList [("k", 99.8)]
+      observables : Map.Map O.Param O.Key = Map.fromList [("s", "VOD.L")]
+      get dict k = fromSome (Map.lookup k dict)
+      f = cmapTime (`subDate` today) (today `addDays`) . mapParams (get observables) (get constants)
+
+  f aTemplate === When (O.TimeGte $ date 2021 Jul 15) (Scale (Observe "VOD.L" - Const 99.8) (One usd) `Or` Zero)

--- a/test/daml/Test/Templating.daml
+++ b/test/daml/Test/Templating.daml
@@ -33,7 +33,13 @@ instance Multiplicative Text where
 
 usd = "USD"
 
-demoTemplate = script do
+demoTemplate = script do 
+  let today = date 2021 Jun 8
+      expr : Observation Int Decimal = O.pure 1.0 + O.observe "key"
+      expr' : Observation Date Decimal = O.pure 1.0 + O.observe "key"
+  O.cmapTime (`subDate` today) expr === expr'
+
+  {-
   let today = date 2021 Jun 8
       call spot strike = O.observe spot - O.pure strike
       aTemplate = european (date 2021 Jul 15 `subDate` today) (Scale (call "s" "k") (One usd))
@@ -43,6 +49,7 @@ demoTemplate = script do
   let constants : Map.Map O.Param Decimal = Map.fromList [("k", 99.8)]
       observables : Map.Map O.Param O.Key = Map.fromList [("s", "VOD.L")]
       get dict k = fromSome (Map.lookup k dict)
-      f = cmapTime (`subDate` today) (today `addDays`) . mapParams (get observables) (get constants)
+      f = mapParams (get observables) (get constants) . cmapTime (`subDate` today) (today `addDays`)
 
   f aTemplate === When (O.TimeGte $ date 2021 Jul 15) (Scale (Observe "VOD.L" - Const 99.8) (One usd) `Or` Zero)
+-}

--- a/test/daml/Test/Templating.daml
+++ b/test/daml/Test/Templating.daml
@@ -6,6 +6,9 @@
 {-# LANGUAGE UndecidableInstances #-} --needed to derive cofree Show,Eq
 
 -- | This gives an example of how to 'template' claims.
+-- The basic idea is to store variable names in the 'holes' in the `Observable` leaves; this creates
+-- a template with placeholders for the actual values we want. We then map these parameters to values
+-- when we're ready to 'issue' the instrument, using `mapParams`.
 module Test.Templating where
 
 import Daml.Script
@@ -46,3 +49,4 @@ demoTemplate = script do
       f = mapParams (`subDate` today) (today `addDays`) (get observables) (get constants)
 
   f aTemplate === When (O.TimeGte $ date 2021 Jul 15) (Scale (Observe "VOD.L" - Const 99.8) (One usd) `Or` Zero)
+

--- a/test/daml/Test/Templating.daml
+++ b/test/daml/Test/Templating.daml
@@ -35,12 +35,6 @@ usd = "USD"
 
 demoTemplate = script do 
   let today = date 2021 Jun 8
-      expr : Observation Int Decimal = O.pure 1.0 + O.observe "key"
-      expr' : Observation Date Decimal = O.pure 1.0 + O.observe "key"
-  O.cmapTime (`subDate` today) expr === expr'
-
-  {-
-  let today = date 2021 Jun 8
       call spot strike = O.observe spot - O.pure strike
       aTemplate = european (date 2021 Jul 15 `subDate` today) (Scale (call "s" "k") (One usd))
 
@@ -49,7 +43,6 @@ demoTemplate = script do
   let constants : Map.Map O.Param Decimal = Map.fromList [("k", 99.8)]
       observables : Map.Map O.Param O.Key = Map.fromList [("s", "VOD.L")]
       get dict k = fromSome (Map.lookup k dict)
-      f = mapParams (get observables) (get constants) . cmapTime (`subDate` today) (today `addDays`)
+      f = mapParams (`subDate` today) (today `addDays`) (get observables) (get constants)
 
   f aTemplate === When (O.TimeGte $ date 2021 Jul 15) (Scale (Observe "VOD.L" - Const 99.8) (One usd) `Or` Zero)
--}


### PR DESCRIPTION
TL; DR
---------

We've changed the encoding of `Observation` so that it admits a `Functor` instance now.

Requirements
-------------------

Let's take a concrete example to explain what this is for.

Currently, if we want to model an options chain, (i.e. options with the same maturity but different strike prices, from low to high), we are required to create n trees of `Claim`s, with _n_ being the number of strikes we want to model.
Ideally, what we'd want to support, is the ability to create claims that have parameters. i.e. a single claim representing an 'option', and then we can use that to either create multiple instances of that option, but with a different strike price.

Solution
-----------

The approach I've taken is to re-model the `Observation` type to make it a proper `Functor`. What this means is that we can now create `Claim`s (by extension of `Observable`s) that have an arbitrary type in the leaves, not just a `Decimal` value.

How does this help us? It means that we can model a 'template', by letting the value type be a `Text`, an identifier name, instead of it's actual decimal value. So instead of creating a `Claim` with it's strike price `99.0`, we have a `Claim` with it's strike price `"strike"`, i.e. a string. This is our template.

Once we want to 'instantiate our template', we simply `fmap` those `Observation`s from their placeholder parameter names (`Text`), to their actual values (`Decimal`). This is trivial to do by passing a `Map` holding those instantiation parameters.
This so-called 'instantiation' can be either done at instrument issue time, or it can be deferred until evaluation; in other words, you have the option of storing your claim instances as `Claim f t Decimal a`, or as a pair of `(Map Text Decimal, Claim f t Text a)`.

Another subtlety which I want to elaborate on here is that of how time is represented in a template vs an instance of it. This is not an enhancement for this PR - it's already there - but I want to bring this to your attention.
When creating a template, I suggest it is stored as `Claim f Int Text a` . i.e. we store dates/times as an ordinal number, with zero being issue date. In our running example, this saves us from having to create multiple templates for the same option but different maturities. We can have a single option, where the maturity is in 30 days time.
Once the option is instantiated, we (contra)map the ordinal value into a `Date` or timestamp.

Implementation
--------------------

A summary of the changes:
- `Observation` signature remains unchanged
- However, inequality operations have been moved into a separate type `Observable.Inequality`
- In fact there is now a single inequality operator `>=`. Equality has been removed. This isn't as restrictive as it sounds - most `Observable`s will represent stochastic processes i.e. probabilities, so the main operation is `<=` rather than `==`. 
- Claim has an extra type parameter, which is passed-through to the `Observable` output parameter.

**Changes to `Observation`**
I've managed to replace the unholy mess on the left-hand side with a much simpler and cleaner implementation.
In the old version, `a` was a phantom type. Now it's actually a concrete value. Although we always envisaged the use of this DSL inside DAML, The advantage of this is that users can now write much safer `Observation`s off-ledger. Degenerate cases are caught at compile time (if the off-ledger language is strongly typed), or at worst at deserialization time - it never makes it onto the ledger.
```diff
 
 -- | Concrete implementation of `Observable`, which can be serialized.
-data Observation t a
-  = DecimalConst Decimal
-  | DecimalObs Key
-  | DecimalLte (Observation t Decimal, Observation t Decimal)
-  | DecimalEqu (Observation t Decimal, Observation t Decimal)
-  | DecimalAdd (Observation t Decimal, Observation t Decimal)
-  | DecimalNeg (Observation t Decimal)
-  | DecimalMul (Observation t Decimal, Observation t Decimal)
-  | DecimalDiv (Observation t Decimal, Observation t Decimal)
-  | BoolConst Bool
-  | DateIdentity
-  | DateConst t
-  | DateLte (Observation t t, Observation t t)
-  | DateEqu (Observation t t, Observation t t)
+-- Conceptually it's helpfult to think of this as the type `t -> x`, or `t -> Update x`.
+data Observation t x
+  = Const with value: x 
+    -- ^ A named constant
+  | Observe with key: O.Key 
+    -- ^ A named parameter
+  | Identity 
+    -- ^ The identity function, `t -> t`; useful for time comparisons.
+    -- e.g. `Inequality(Identity, Const "tomorrow" (date _))` equates to `time <= tomorrow`
+  | Add (Observation t x, Observation t x)
+  | Neg (Observation t x)
+  | Mul (Observation t x, Observation t x)
+  | Div (Observation t x, Observation t x)
   deriving (Eq, Show)
 ```
Below is an example of how this simplifies the algebra, having a `Functor` instance. Previously we relied on typeclass tricks in order to prevent users from creating and evaluating invalid `Observation`s. You can see that 'degenerate' cases trigger failure in `eval _ _ = error` in the old approach. Now those valid cases can't even be created anymore (ok, there are still some exceptions, but it's _much_ safe now!).


```diff
-class Interpret t a where
-  eval : Monad m => (Key -> t -> m Decimal) -> Observation t a -> Kleisli m t a
-
-instance Ord t => Interpret t Bool where
-  eval _ (BoolConst b) = pure b
-  eval spot (DecimalLte (d, d')) = liftA2 (<=) (eval spot d) (eval spot d')
-  eval spot (DecimalEqu (d, d')) = liftA2 (==) (eval spot d) (eval spot d')
-  eval spot (DateLte (d, d')) = liftA2 (<=) (eval spot d) (eval spot d')
-  eval spot (DateEqu (d, d')) = liftA2 (==) (eval spot d) (eval spot d')
-  eval _ _ = error "eval: Interpret Bool"
-
-instance Interpret t t where
-  eval _ (DateConst t) = pure t
-  eval _ DateIdentity = id
-  eval _ _ = error "eval: Interpret Date"
-
-instance Interpret t Decimal where
-  eval _ (DecimalConst d) = pure d
-  eval spot (DecimalObs key) = Kleisli $ spot key
-  eval spot (DecimalAdd (x, x')) = liftA2 (+) (eval spot x) (eval spot x')
-  eval spot (DecimalNeg x) = fmap (\x -> (- x)) (eval spot x)
-  eval spot (DecimalMul (x, x')) = liftA2 (*) (eval spot x) (eval spot x')
-  eval spot (DecimalDiv (x, x')) = liftA2 (/) (eval spot x) (eval spot x')
-  eval _ _ = error "eval: Interpret Decimal"
+eval : (Divisible x, Number x, Monad m) 
+     => (t -> x)
+     -> (O.Key -> t -> m x) 
+     -> Observation t x 
+     -> Kleisli m t x
+eval yoneda doObserve = cataM \case
+  ConstF x -> pure x
+  ObserveF key -> Kleisli (doObserve key)
+  AddF (x, x') -> pure $ x Prelude.+ x'
+  NegF x -> pure $ negate x
+  MulF (x, x') -> pure $ x * x'
+  DivF (x, x') -> pure $ x / x'
+  IdentityF -> arr yoneda
```

**Changes to `Claim`**

We now pass-thru the output type of `Observable`, so it becomes visible in `Claim`. Having one more parameter increases complexity, but this is the trade-off.

```diff
-data Claim f t a
+data Claim f t x a
```

There is also a new type `Inequality`. This is require to make the new `Observation` algebra sound, because the signature of inequalities (`a -> a -> Bool`) is different from that of ring operations (`a -> a -> a`).

```haskell
-- | Think of this as `f t t ≤ f t t | f t x ≤ f t x`
data Inequality f t x = LteT (f t t, f t t) | LteX (f t x, f t x)
```
And it's used here:
```diff
-  | When with predicate: f t Bool, claim: Claim f t a
+  | When with predicate: Inequality f t x, claim: Claim f t x a
```