### PR TITLE
Simplify the 'american' combinator

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,6 +1,6 @@
 sdk-version: 1.13.1
 name: contingent-claims
-version: 0.0.1
+version: 0.0.2
 source: daml
 parties:
 - Buyer

--- a/daml/ContingentClaims/FinancialClaim.daml
+++ b/daml/ContingentClaims/FinancialClaim.daml
@@ -23,7 +23,7 @@ unrollDates issueYear maturityYear fixingMonths fixingDay =
 forward : Observable f t x => t -> f t x -> Claim f t x a -> Claim f t x a
 forward maturity r payoff = When (at maturity) $ Scale r payoff
 
--- | Forward rate agreement. 
+-- | Forward rate agreement.
 fra : Observable f t x => t -> t -> f t x -> f t x -> Claim f t x a -> Claim f t x a
 fra t₁ t₂ r₀ r₁ = forward t₁ r₀ . forward t₂ r₁
 
@@ -34,7 +34,7 @@ zcb maturity principal ccy = forward maturity (O.pure principal) (One ccy)
 -- | A floating rate bond. The first two arguments are `Observable`s.
 floating : Observable f t x => f t x -> f t x -> ccy -> [t] -> Claim f t x ccy
 floating principal coupon asset = apo \case
-     [maturity] -> Left (forward maturity coupon (One asset)) `AndF` 
+     [maturity] -> Left (forward maturity coupon (One asset)) `AndF`
                    Left (forward maturity principal (One asset))
      (t :: ts) -> Left (forward t coupon (One asset)) `AndF` Right ts
      [] -> ZeroF
@@ -57,9 +57,9 @@ bermudan u = apo \case
   [] -> ZeroF
 
 -- | American option (knock-in). The lead parameter is the first possible acquisition date.
-american : Enum t => t -> t -> Claim f t x a -> Claim f t x a
-american t maturity payoff = 
-  Until (at (succ maturity)) $
+american : t -> t -> Claim f t x a -> Claim f t x a
+american t maturity payoff =
+  Until (at maturity) $
     Anytime ((>=) t) (payoff `Or` Zero)
   where (>=) = at
 

--- a/test/daml.yaml
+++ b/test/daml.yaml
@@ -1,6 +1,6 @@
 sdk-version: 1.13.1
 name: contingent-claims-test
-version: 0.0.1
+version: 0.0.2
 source: daml
 init-script: Test.Initialization:createContracts
 parties:

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -19,7 +19,7 @@ import ContingentClaims.Observation qualified as O
 import ContingentClaims.Util.Recursion
 import DA.Action ((>=>))
 import DA.Assert ((===))
-import DA.Date (date, Month(..), addDays, toDateUTC)
+import DA.Date (date, Month(..), toDateUTC)
 import DA.Time (time)
 import Daml.Control.Arrow (runKleisli)
 import Daml.Control.Monad.Writer (runWriterT)
@@ -36,8 +36,8 @@ deriving instance Eq a => Eq (F a)
 
 [a,b,c] = ["a","b","c"]
 today = date 1970 Jan 1
-tomorrow = today `addDays` 1
-afterTomorrow = tomorrow `addDays` 1
+tomorrow = succ today
+afterTomorrow = succ tomorrow
 two : O.Observation Date Decimal = O.pure 2.0
 observe25: Text -> Date -> Script Decimal = const . const . pure $ 25.0
 false = O.TimeGte $ date 3000 Jan 1
@@ -258,7 +258,7 @@ testAmericanPut = script do
   setDate tomorrow
   t <- getDate
 
-  -- Settlement before exercise has been done is a no-op
+  -- Settlement before exercise is a no-op
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
   remaining === option
   pending === []
@@ -268,10 +268,10 @@ testAmericanPut = script do
   remaining === option
 
   remaining <- Lifecycle.exercise observe25 (bearer, payoff `Or` Zero) remaining t
-  remaining === Until (O.TimeGte $ succ afterTomorrow) (payoff `Or` Zero)
+  remaining === Until (O.TimeGte $ afterTomorrow) (payoff `Or` Zero)
 
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
-  remaining === Until (O.TimeGte $ succ afterTomorrow) payoff
+  remaining === Until (O.TimeGte afterTomorrow) payoff
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === Zero
@@ -281,14 +281,14 @@ testAmericanPut = script do
   setDate afterTomorrow
   t <- getDate
 
+  -- Expiration at maturity n.b. this means you must *first* exercise & settle *before* expiring.
+  remaining <- Lifecycle.expire observe25 option t
+  remaining === Zero
+
   -- Settlement before exercise has been done is a no-op
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
   remaining === option
   pending === []
-
-  -- So is expiration before maturity
-  remaining <- Lifecycle.expire observe25 remaining t
-  remaining === option
 
   -- Trying to exercise inner `Or` before `Anytime` won't work.
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
@@ -296,22 +296,22 @@ testAmericanPut = script do
 
   -- You must first exercise the 'outer' `Anytime`, and then ...
   remaining <- Lifecycle.exercise observe25 (bearer, payoff `Or` Zero) remaining t
-  remaining === Until (O.TimeGte $ succ afterTomorrow) (payoff `Or` Zero)
+  remaining === Until (O.TimeGte $ afterTomorrow) (payoff `Or` Zero)
 
   -- ... the inner `Or`.
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
-  remaining === Until (O.TimeGte $ succ afterTomorrow) payoff
+  remaining === Until (O.TimeGte $ afterTomorrow) payoff
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === Zero
   pending === pure (5.0, a)
 
-  -- Scenario 4) afte expiration
+  -- Scenario 4) after expiration
   setDate $ succ afterTomorrow
   t <- getDate
 
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t
-  remaining === option -- passed maturity; no exercise possible
+  remaining === option -- past maturity; no exercise possible
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === option


### PR DESCRIPTION
This is a change that modifies the behaviour of the `american` combinator.

It was changed like so:

```diff
-american : Enum t => t -> t -> Claim f t x a -> Claim f t x a
+american : t -> t -> Claim f t x a -> Claim f t x a
```

The difference is that previously we used the `Enum` property to find the 'next' `t`, so that expiry could only be done *after*  maturity. This in turn was necessary due to the restrictive ADT we use for `Observable`s - we only allow comparison of 'time greater than or equal to `t`'. The main reason for having this was to restrict the complexity of predicates that could be written, and in turn the complexity of interpreters we need to write; also, without this, it was possible to e.g. compare a time variable with a real value.

That digression aside, what this means in practice, is that if you're using `Date` as your time parameter, then running `Lifecycle.expire` on maturity date will expire the instrument. This seems like the logical/desirable thing. Previously it would only expire the following day.
But you have to be careful now that if you run `Lifecycle.{exercise,lifecycle}` on maturity, that you do this *before* you run `Lifecycle.expire`. This is also evidenced in the tests (lines 284/289 in old/new file). I think this is the reason I had done this originally.

This was considerably less of a problem if using `Time` as your `t` parameter. But really problematic if using a symbol e.g. `Text` as the time parameter.

