### PR TITLE
Fix bermudan option builder

### DIFF
--- a/daml/ContingentClaims/Financial.daml
+++ b/daml/ContingentClaims/Financial.daml
@@ -53,7 +53,7 @@ european maturity payoff = When (at maturity) (payoff `or` zero)
 bermudan : [t] -> Claim t x a -> Claim t x a
 bermudan [] _ = zero
 bermudan [t] c = european t c
-bermudan (t :: ts) c = When (at t) $ Or c (bermudan ts c) []
+bermudan (t :: ts) c = when (at t) (c `or` bermudan ts c)
 
 -- | American option (knock-in). The lead parameter is the first possible acquisition date.
 american : t -> t -> Claim t x a -> Claim t x a

--- a/daml/ContingentClaims/Financial.daml
+++ b/daml/ContingentClaims/Financial.daml
@@ -49,7 +49,9 @@ fixed principal coupon = floating (O.pure principal) (O.pure coupon)
 european : t -> Claim t x a -> Claim t x a
 european maturity payoff = When (at maturity) (payoff `or` zero)
 
--- | Bermudan option on the passed claim. Given a pre-defined set of times {t_1, t_2, .., t_N}, it allows the holder to acquire the underlying claim on at most one of these times.
+-- | Bermudan option on the passed claim. Given a pre-defined set of times
+-- {t_1, t_2, .., t_N}, it allows the holder to acquire the underlying claim on at
+-- most one of these times.
 bermudan : [t] -> Claim t x a -> Claim t x a
 bermudan [] _ = zero
 bermudan [t] c = european t c

--- a/daml/ContingentClaims/Financial.daml
+++ b/daml/ContingentClaims/Financial.daml
@@ -49,11 +49,11 @@ fixed principal coupon = floating (O.pure principal) (O.pure coupon)
 european : t -> Claim t x a -> Claim t x a
 european maturity payoff = When (at maturity) (payoff `or` zero)
 
--- | Bermudan option on the passed claim.
-bermudan : Claim t x a -> [t] -> Claim t x a
-bermudan _ [] = zero
-bermudan c [t] = european t c
-bermudan c (t :: t' :: ts) = Or (european t c) (european t' c) (fmap (`european` c) ts) -- This is written like this for efficiency
+-- | Bermudan option on the passed claim. Given a pre-defined set of times {t_1, t_2, .., t_N}, it allows the holder to acquire the underlying claim on at most one of these times.
+bermudan : [t] -> Claim t x a -> Claim t x a
+bermudan [] _ = zero
+bermudan [t] c = european t c
+bermudan (t :: ts) c = When (at t) $ Or c (bermudan ts c) []
 
 -- | American option (knock-in). The lead parameter is the first possible acquisition date.
 american : t -> t -> Claim t x a -> Claim t x a


### PR DESCRIPTION
Unless I misunderstood the semantics of Or, this should be the desired implementation of a builder for a bermudan option.

I am also re-ordering inputs to be consistent with european and american. This is a breaking change, but we are bumping to version 2.0.0 so it should be allowed if using semantic versioning