### PR TITLE
Better `Show` instances. Fixes #23

### DIFF
--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -47,23 +47,6 @@ data Claim t x a
       -- ^ Expires said claim on the *first instant* that `predicate` is true.
   deriving (Eq)
 
-instance (Show t, Show x, Show a) => Show (Claim t x a) where
-  show = para \case
-    ZeroF -> "Zero"
-    OneF a -> unwords ["One", show a]
-    GiveF (_, s) -> unwords ["Give", bracket s]
-    AndF (_, s) (_, s') cs -> print3 "And" s s' (Prelude.fst <$> cs)
-    OrF (_, s) (_, s') cs -> print3 "Or" s s' (Prelude.fst <$> cs)
-    CondF b (_, s) (_, s') -> unwords ["Cond", bracket (show b), bracket s, bracket  s']
-    ScaleF x (_, s) -> print2 "Scale" x s
-    WhenF b (_, s) -> print2 "When" b s
-    AnytimeF b (_, s) -> print2 "Anytime" b s
-    UntilF b (_, s) -> print2 "Until" b s
-    where print3 c s s' cs = unwords [c, bracket s, bracket s', show cs]
-          print2 c x s = unwords [c, bracket (show x), bracket s]
-          bracket "Zero" = "Zero"
-          bracket s = "(" <> s <> ")"
-
 -- | Smart constructor for `Zero`.
 zero : forall t x a . Claim t x a
 zero = Zero
@@ -217,6 +200,23 @@ instance Traversable (ClaimF t x b) where
   sequence (CondF p fa fa') = CondF p <$> fa <*> fa'
   sequence (AnytimeF p fa) = AnytimeF p <$> fa
   sequence (UntilF p fa) = UntilF p <$> fa
+
+instance (Show t, Show x, Show a) => Show (Claim t x a) where
+  show = para \case
+    ZeroF -> "Zero"
+    OneF a -> unwords ["One", show a]
+    GiveF (_, s) -> unwords ["Give", bracket s]
+    AndF (_, s) (_, s') cs -> print3 "And" s s' (Prelude.fst <$> cs)
+    OrF (_, s) (_, s') cs -> print3 "Or" s s' (Prelude.fst <$> cs)
+    CondF b (_, s) (_, s') -> unwords ["Cond", bracket (show b), bracket s, bracket  s']
+    ScaleF x (_, s) -> print2 "Scale" x s
+    WhenF b (_, s) -> print2 "When" b s
+    AnytimeF b (_, s) -> print2 "Anytime" b s
+    UntilF b (_, s) -> print2 "Until" b s
+    where print3 c s s' cs = unwords [c, bracket s, bracket s', show cs]
+          print2 c x s = unwords [c, bracket (show x), bracket s]
+          bracket "Zero" = "Zero"
+          bracket s = "(" <> s <> ")"
 
 -- Inequality --
 

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -5,15 +5,14 @@
 
 module ContingentClaims.Claim where
 
-import Prelude hiding (or, and, fst, snd)
-import Prelude qualified as Prelude (fst, snd)
-import Daml.Control.Arrow (Kleisli(..), arr)
-import Daml.Control.Recursion
-import ContingentClaims.Observation (Observation)
 import ContingentClaims.Observation qualified as Observation
+import ContingentClaims.Observation (Observation)
 import DA.Foldable (Foldable(..))
+import DA.Text (unwords, intercalate)
 import DA.Traversable (Traversable(..))
-import DA.Text (unwords)
+import Daml.Control.Recursion
+import Daml.Control.Arrow (Kleisli(..), arr)
+import Prelude hiding (or, and, fst, snd)
 
 type T = Claim
 type F = ClaimF
@@ -202,18 +201,18 @@ instance Traversable (ClaimF t x b) where
   sequence (UntilF p fa) = UntilF p <$> fa
 
 instance (Show t, Show x, Show a) => Show (Claim t x a) where
-  show = para \case
+  show = cata \case
     ZeroF -> "Zero"
     OneF a -> unwords ["One", show a]
-    GiveF (_, s) -> unwords ["Give", bracket s]
-    AndF (_, s) (_, s') cs -> print3 "And" s s' (Prelude.fst <$> cs)
-    OrF (_, s) (_, s') cs -> print3 "Or" s s' (Prelude.fst <$> cs)
-    CondF b (_, s) (_, s') -> unwords ["Cond", bracket (show b), bracket s, bracket  s']
-    ScaleF x (_, s) -> print2 "Scale" x s
-    WhenF b (_, s) -> print2 "When" b s
-    AnytimeF b (_, s) -> print2 "Anytime" b s
-    UntilF b (_, s) -> print2 "Until" b s
-    where print3 c s s' cs = unwords [c, bracket s, bracket s', show cs]
+    GiveF s -> unwords ["Give", bracket s]
+    AndF s s' cs -> print3 "And" s s' cs
+    OrF s s' cs -> print3 "Or" s s' cs
+    CondF b s s' -> unwords ["Cond", bracket (show b), bracket s, bracket  s']
+    ScaleF x s -> print2 "Scale" x s
+    WhenF b s -> print2 "When" b s
+    AnytimeF b s -> print2 "Anytime" b s
+    UntilF b s -> print2 "Until" b s
+    where print3 c s s' cs = unwords [c, bracket s, bracket s', "[" <> intercalate ", " cs <> "]"]
           print2 c x s = unwords [c, bracket (show x), bracket s]
           bracket "Zero" = "Zero"
           bracket s = "(" <> s <> ")"

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -12,6 +12,7 @@ import ContingentClaims.Observation (Observation)
 import ContingentClaims.Observation qualified as Observation
 import DA.Foldable (Foldable(..))
 import DA.Traversable (Traversable(..))
+import DA.Text (unwords)
 
 type T = Claim
 type F = ClaimF
@@ -43,7 +44,22 @@ data Claim t x a
       -- ^ Like `When`, but valid any time the predicate is true (not just infinium).
   | Until with predicate: Inequality t x a, claim: Claim t x a
       -- ^ Expires said claim on the *first instant* that `predicate` is true.
-  deriving (Show, Eq)
+  deriving (Eq)
+
+instance (Show t, Show x, Show a) => Show (Claim t x a) where
+  show = cata \case
+    ZeroF -> "Zero"
+    OneF a -> "One " <> show a
+    GiveF s -> print "Give" [s]
+    AndF s s' ss -> print "And" $ s :: s' :: ss
+    OrF s s' ss -> print "Or" $ s :: s' :: ss
+    CondF b s s' -> print "Cond" [show b, s, s']
+    ScaleF x s -> print "Scale" [show x, s]
+    WhenF b s -> print "When" [show b, s]
+    AnytimeF b s -> print "Anytime" [show b, s]
+    UntilF b s -> print "Until" [show b, s]
+    where print c ss = unwords $ c :: fmap bracket ss
+          bracket s = "(" <> s <> ")"
 
 -- | Smart constructor for `Zero`.
 zero : forall t x a . Claim t x a

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -6,6 +6,7 @@
 module ContingentClaims.Claim where
 
 import Prelude hiding (or, and, fst, snd)
+import Prelude qualified as Prelude (fst, snd)
 import Daml.Control.Arrow (Kleisli(..), arr)
 import Daml.Control.Recursion
 import ContingentClaims.Observation (Observation)
@@ -47,21 +48,21 @@ data Claim t x a
   deriving (Eq)
 
 instance (Show t, Show x, Show a) => Show (Claim t x a) where
-  show claim = f claim False
-    where f Zero = const "Zero"
-          f (One a) = print $ "One " <> show a
-          f (Give c) = print $ unwords ["Give", print c True]
-          f (And c c' cs) = print $ unwords ["And", print c True, print c' True, print cs False]
-          f (Or c c' cs) =  print $ unwords ["Or", print c True, print c' True, print cs False]
-          f (Cond p c c') = print $ unwords ["Cond", print p True, print c True, print c' True]
-          f (Scale o c) = print $ unwords ["Scale", print c True]
-          f (When p c) = print $ unwords ["When", print p True, print c True]
-          f (Anytime p c) = print $ unwords ["When", print p True, print c True]
-          f (Until p c) = print $ unwords ["Until", print p True, print c True]
-          print x brackets = if brackets then bracket x else show x
-          bracket s = "(" <> show s <> ")" 
-
--- print : Show x => x -> Bool -> Text
+  show = para \case
+    ZeroF -> "Zero"
+    OneF a -> unwords ["One", show a]
+    GiveF (_, s) -> unwords ["Give", bracket s]
+    AndF (_, s) (_, s') cs -> print3 "And" s s' (Prelude.fst <$> cs)
+    OrF (_, s) (_, s') cs -> print3 "Or" s s' (Prelude.fst <$> cs)
+    CondF b (_, s) (_, s') -> unwords ["Cond", bracket (show b), bracket s, bracket  s']
+    ScaleF x (_, s) -> print2 "Scale" x s
+    WhenF b (_, s) -> print2 "When" b s
+    AnytimeF b (_, s) -> print2 "Anytime" b s
+    UntilF b (_, s) -> print2 "Until" b s
+    where print3 c s s' cs = unwords [c, bracket s, bracket s', show cs]
+          print2 c x s = unwords [c, bracket (show x), bracket s]
+          bracket "Zero" = "Zero"
+          bracket s = "(" <> s <> ")"
 
 -- | Smart constructor for `Zero`.
 zero : forall t x a . Claim t x a

--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -47,19 +47,21 @@ data Claim t x a
   deriving (Eq)
 
 instance (Show t, Show x, Show a) => Show (Claim t x a) where
-  show = cata \case
-    ZeroF -> "Zero"
-    OneF a -> "One " <> show a
-    GiveF s -> print "Give" [s]
-    AndF s s' ss -> print "And" $ s :: s' :: ss
-    OrF s s' ss -> print "Or" $ s :: s' :: ss
-    CondF b s s' -> print "Cond" [show b, s, s']
-    ScaleF x s -> print "Scale" [show x, s]
-    WhenF b s -> print "When" [show b, s]
-    AnytimeF b s -> print "Anytime" [show b, s]
-    UntilF b s -> print "Until" [show b, s]
-    where print c ss = unwords $ c :: fmap bracket ss
-          bracket s = "(" <> s <> ")"
+  show claim = f claim False
+    where f Zero = const "Zero"
+          f (One a) = print $ "One " <> show a
+          f (Give c) = print $ unwords ["Give", print c True]
+          f (And c c' cs) = print $ unwords ["And", print c True, print c' True, print cs False]
+          f (Or c c' cs) =  print $ unwords ["Or", print c True, print c' True, print cs False]
+          f (Cond p c c') = print $ unwords ["Cond", print p True, print c True, print c' True]
+          f (Scale o c) = print $ unwords ["Scale", print c True]
+          f (When p c) = print $ unwords ["When", print p True, print c True]
+          f (Anytime p c) = print $ unwords ["When", print p True, print c True]
+          f (Until p c) = print $ unwords ["Until", print p True, print c True]
+          print x brackets = if brackets then bracket x else show x
+          bracket s = "(" <> show s <> ")" 
+
+-- print : Show x => x -> Bool -> Text
 
 -- | Smart constructor for `Zero`.
 zero : forall t x a . Claim t x a

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -9,10 +9,10 @@
 module ContingentClaims.Observation where
 
 import ContingentClaims.Util.Recursion (cataM)
+import DA.Foldable (Foldable(..))
+import DA.Traversable (Traversable(..))
 import Daml.Control.Arrow (Kleisli(..))
 import Daml.Control.Recursion (Recursive(..), Corecursive(..), project, embed)
-import DA.Traversable (Traversable(..))
-import DA.Foldable (Foldable(..))
 import Prelude hiding (key, (.), pure)
 import qualified Prelude (pure)
 
@@ -29,7 +29,7 @@ data Observation t x a
   | Neg (Observation t x a)
   | Mul (Observation t x a, Observation t x a)
   | Div (Observation t x a, Observation t x a)
-  deriving (Eq, Show, Functor)
+  deriving (Eq, Functor)
 
 data ObservationF t x a b
   = ConstF with value: x
@@ -126,3 +126,13 @@ instance Traversable (ObservationF t x a) where
   sequence (AddF (m, m')) = curry AddF <$> m <*> m'
   sequence (MulF (m, m')) = curry MulF <$> m <*> m'
   sequence (DivF (m, m')) = curry DivF <$> m <*> m'
+
+instance (Show t, Show x, Show a) => Show (Observation t x a) where
+  show = cata \case
+    ConstF x -> "Const " <> show x
+    ObserveF a -> "Observe " <> show a
+    AddF ss -> pair "Add" ss
+    NegF s -> "Neg (" <> s <> ")"
+    MulF ss -> pair "Mul" ss
+    DivF ss -> pair "Div" ss
+    where pair o (s, s') = o <> " (" <> s <> ", " <> s' <> ")"


### PR DESCRIPTION
Also related to #46 

This implements custom `Show` instance for `Observation` and `Claim`, which simply remove field names from the output. It makes debugging large trees easier. 

No attempt is made to prettify the output (i.e. changing to infix notation, on changing the constructor names).