### PR TITLE
Make `acquire` non-effectful. Fixes #47.

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -75,17 +75,18 @@ lifecycle spot
     foldE (Right x) = x
 
 -- | Evaluate observables and skip branches for which predicates don't hold.
--- Consumes `When` and `Cond` when appropriate, leaving their subtrees.
 -- This is useless on its own. Composed with other functions, it adds laziness.
 acquire' : (Ord t, Eq a, Monad m)
   => (a -> t -> m Decimal)
   -> C t a -> Kleisli m t (F t a (Either (C t a) (C t a)))
 acquire' spot (When obs c) = do
   predicate <- compare spot obs
-  if predicate then acquire' spot c else pure $ WhenF obs (Left c)
+  pure $ WhenF obs if predicate then Right c else Left c
 acquire' spot (Cond obs c c') = do
   predicate <- compare spot obs
-  if predicate then acquire' spot c else acquire' spot c'
+  pure if predicate 
+    then CondF obs (Right c) (Left c') 
+    else CondF obs (Left c) (Right c')
 acquire' spot (Anytime obs c) = do
   predicate <- compare spot obs
   pure $ AnytimeF obs if predicate then Right c else Left c

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -312,3 +312,19 @@ testAmericanPut = script do
 
   remaining <- Lifecycle.expire observe25 remaining t
   remaining === zero
+
+testFloatingRateNote = script do
+  let 
+    innerFrn = Scale (O.Observe a) $ When (TimeGte $ date 2022 Mar 10) $ One b
+    frn = When (TimeGte $ date 2022 Mar 01) innerFrn
+
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Feb 28
+  remaining === frn
+
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 01
+  remaining === innerFrn -- this should apparently not be the case, but rather remaining === frn
+
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 10
+  remaining === Zero
+  pending === [(25.0,b)]
+

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -315,7 +315,7 @@ testAmericanPut = script do
   remaining === zero
 
 testFloatingRateNote = script do
-  let 
+  let
     innerFrn = Scale (O.Observe a) $ When (TimeGte $ date 2022 Mar 10) $ One b
     frn = When (TimeGte $ date 2022 Mar 01) innerFrn
 
@@ -328,22 +328,3 @@ testFloatingRateNote = script do
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 10
   remaining === Zero
   pending === [(25.0,b)]
-
-testUntilNodes = script do
-  let 
-    payment = When (TimeGte (date 2022 Apr 10)) (One "EUR")
-    claim = 
-        Until (TimeGte (date 2022 Apr 07)) $ payment
-
-  -- I would expect the below operation to expire the contract (because the until condition evaluates to True). However, it does not seem to be the case.
-  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 claim (date 2022 Apr 08)
-  pending === []
-  remaining === claim -- expecting Zero
-
-  -- Wrong payment is made on Apr 10
-  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 remaining (date 2022 Apr 10)
-  pending === [(1.0, "EUR")] -- expecting []
-  remaining === Zero
-
-  pure ()
-

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -328,3 +328,21 @@ testFloatingRateNote = script do
   remaining === Zero
   pending === [(25.0,b)]
 
+testUntilNodes = script do
+  let 
+    payment = When (TimeGte (date 2022 Apr 10)) (One "EUR")
+    claim = 
+        Until (TimeGte (date 2022 Apr 07)) $ payment
+
+  -- I would expect the below operation to expire the contract (because the until condition evaluates to True). However, it does not seem to be the case.
+  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 claim (date 2022 Apr 08)
+  pending === []
+  remaining === claim -- expecting Zero
+
+  -- Wrong payment is made on Apr 10
+  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 remaining (date 2022 Apr 10)
+  pending === [(1.0, "EUR")] -- expecting []
+  remaining === Zero
+
+  pure ()
+

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -56,13 +56,13 @@ testAcquire = script do
   res === when (at tomorrow) (scale two (one a))
 
   res <- f (when (at tomorrow) $ scale two (one a)) tomorrow
-  res === scale two (acquired a)
+  res === when (at tomorrow) (scale two (acquired a))
 
   res <- f (cond (at tomorrow) (one a) (one b)) today
-  res === acquired b
+  res === cond (at tomorrow) (one a) (acquired b)
 
   res <- f (cond (at tomorrow) (one a) (one b)) tomorrow
-  res === acquired a
+  res === cond (at tomorrow) (acquired a) (one b)
 
 {- FIXME: confirm if this test makes sense; it broke when we changed observable with inequality
   res <- f (when (O.TimeGte today) (when (O.TimeGte tomorrow) (one a)) ) tomorrow
@@ -70,7 +70,7 @@ testAcquire = script do
 -}
 
   res <- f (when (TimeGte today) (when (TimeGte tomorrow) (one a)) ) tomorrow
-  res === acquired a
+  res === when (TimeGte today) (when (TimeGte tomorrow) (acquired a))
 
   res <- f (one a `or` one b) today
   res === acquired a `or` acquired b
@@ -221,13 +221,14 @@ testEuropeanCall = script do
   t <- getDate
 
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t
-  remaining === payoff
+  remaining === when (at tomorrow) payoff
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
   pending === pure (2.0, a)
 
 -- Knock-in tomorrow
+testAmericanPut : Script ()
 testAmericanPut = script do
   let strike = 30.0
       payoff = scale (O.pure strike - O.observe "spot") (one a)
@@ -322,7 +323,7 @@ testFloatingRateNote = script do
   remaining === frn
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 01
-  remaining === innerFrn -- this should apparently not be the case, but rather remaining === frn
+  remaining === frn
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 10
   remaining === Zero


### PR DESCRIPTION
This was causing problems as described in #47 

It would be nice to write the proof for this @matteolimberto-da . I would appreciate your comments on this change. Is what we're doing semantically correct?

I think a separate option that has been discussed is to replace any `When t . Scale (observe x)` nodes of the tree with `Scale (const x)`. It's not wrong, but I would be against this, because it mutates the tree unnecessarily. This means that if you lifecycle the tree using this logic, the number of possible 'states' of the tree will be larger than if you don't do this. In the converse case, you only ever store versions of the tree that require user action (exercise or settlement), if that makes sense.
The other ambiguity of that approach is whether we should now check for all case `When t . claim` where `claim ≠ When`? The more of these 'special cases' we have, the more surprising behaviour we will see.