### PR TITLE
`acquire'` now respects `Until`. Fix #49.

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -17,7 +17,7 @@ module ContingentClaims.Lifecycle (
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..), compare)
 import ContingentClaims.Observation qualified as Observation
-import ContingentClaims.Util.Recursion (apoCataM)
+import ContingentClaims.Util.Recursion (apoCataM, hyloM)
 import ContingentClaims.Util (pruneZeros')
 import Daml.Control.Recursion (project, embed, distApo)
 import Daml.Control.Monad.Trans.Writer (WriterT, runWriterT)
@@ -90,6 +90,9 @@ acquire' spot (Cond obs c c') = do
 acquire' spot (Anytime obs c) = do
   predicate <- compare spot obs
   pure $ AnytimeF obs if predicate then Right c else Left c
+acquire' spot (Until obs c) = do
+  predicate <- compare spot obs
+  pure $ UntilF obs if predicate then Left c else Right c
 acquire' _ other = pure $ Right <$> project other
 
 -- | Evaluate any observables in `Scale` nodes, accumulating scale factors
@@ -145,24 +148,11 @@ exercise' _ (isBearer, other) = Right . (isBearer, ) <$> project other
 
 -- | Replace any subtrees that have expired with `Zero`s.
 expire : (Ord t, Eq a, Monad m) => (a -> t -> m Decimal) -> C t a -> t -> m (C t a)
-expire spot = runKleisli . apoCataM pruneZeros' acquireThenExpire where
-  acquireThenExpire = fmap (fmap distE)
-                      . fmap join
-                      . fmap (fmap sequence)
-                      . fmap (fmap (fmap (expire' spot)))
-                      . fmap (fmap (fmap embed))
-                      . fmap (fmap tsidE)
-                      $ acquire' spot
-  distE = distApo
-  tsidE f = case sequence_ f of
-    Left _ -> Left (embed (fmap foldE f))
-    Right _ -> Right (fmap foldE f)
-  foldE (Left x) = x
-  foldE (Right x) = x
+expire spot = runKleisli . hyloM pruneZeros' (expire' spot)
 
 -- | Coalgebra for `expire`.
 expire' : (Ord t, Monad m) => (a -> t -> m Decimal) -> C t a -> Kleisli m t (F t a (C t a))
 expire' spot (Until obs c) = do
   predicate <- compare spot obs
-  if predicate then pure ZeroF else pure $ UntilF obs c
+  pure if predicate then ZeroF else UntilF obs c
 expire' _ other = pure . project $ other

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -75,17 +75,18 @@ lifecycle spot
     foldE (Right x) = x
 
 -- | Evaluate observables and skip branches for which predicates don't hold.
--- Consumes `When` and `Cond` when appropriate, leaving their subtrees.
 -- This is useless on its own. Composed with other functions, it adds laziness.
 acquire' : (Ord t, Eq a, Monad m)
   => (a -> t -> m Decimal)
   -> C t a -> Kleisli m t (F t a (Either (C t a) (C t a)))
 acquire' spot (When obs c) = do
   predicate <- compare spot obs
-  if predicate then acquire' spot c else pure $ WhenF obs (Left c)
+  pure $ WhenF obs if predicate then Right c else Left c
 acquire' spot (Cond obs c c') = do
   predicate <- compare spot obs
-  if predicate then acquire' spot c else acquire' spot c'
+  pure if predicate 
+    then CondF obs (Right c) (Left c') 
+    else CondF obs (Left c) (Right c')
 acquire' spot (Anytime obs c) = do
   predicate <- compare spot obs
   pure $ AnytimeF obs if predicate then Right c else Left c

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -312,3 +312,19 @@ testAmericanPut = script do
 
   remaining <- Lifecycle.expire observe25 remaining t
   remaining === zero
+
+testFloatingRateNote = script do
+  let 
+    innerFrn = Scale (O.Observe a) $ When (TimeGte $ date 2022 Mar 10) $ One b
+    frn = When (TimeGte $ date 2022 Mar 01) innerFrn
+
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Feb 28
+  remaining === frn
+
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 01
+  remaining === innerFrn -- this should apparently not be the case, but rather remaining === frn
+
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 10
+  remaining === Zero
+  pending === [(25.0,b)]
+

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -315,7 +315,7 @@ testAmericanPut = script do
   remaining === zero
 
 testFloatingRateNote = script do
-  let 
+  let
     innerFrn = Scale (O.Observe a) $ When (TimeGte $ date 2022 Mar 10) $ One b
     frn = When (TimeGte $ date 2022 Mar 01) innerFrn
 
@@ -328,22 +328,3 @@ testFloatingRateNote = script do
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 10
   remaining === Zero
   pending === [(25.0,b)]
-
-testUntilNodes = script do
-  let 
-    payment = When (TimeGte (date 2022 Apr 10)) (One "EUR")
-    claim = 
-        Until (TimeGte (date 2022 Apr 07)) $ payment
-
-  -- I would expect the below operation to expire the contract (because the until condition evaluates to True). However, it does not seem to be the case.
-  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 claim (date 2022 Apr 08)
-  pending === []
-  remaining === claim -- expecting Zero
-
-  -- Wrong payment is made on Apr 10
-  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 remaining (date 2022 Apr 10)
-  pending === [(1.0, "EUR")] -- expecting []
-  remaining === Zero
-
-  pure ()
-

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -328,3 +328,21 @@ testFloatingRateNote = script do
   remaining === Zero
   pending === [(25.0,b)]
 
+testUntilNodes = script do
+  let 
+    payment = When (TimeGte (date 2022 Apr 10)) (One "EUR")
+    claim = 
+        Until (TimeGte (date 2022 Apr 07)) $ payment
+
+  -- I would expect the below operation to expire the contract (because the until condition evaluates to True). However, it does not seem to be the case.
+  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 claim (date 2022 Apr 08)
+  pending === []
+  remaining === claim -- expecting Zero
+
+  -- Wrong payment is made on Apr 10
+  Lifecycle.Result{pending,remaining} <- Lifecycle.lifecycle observe25 remaining (date 2022 Apr 10)
+  pending === [(1.0, "EUR")] -- expecting []
+  remaining === Zero
+
+  pure ()
+

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -85,7 +85,7 @@ testAcquire = script do
   res === until false (acquired a)
 
   res <- f (until true (one a)) today
-  res === until true (acquired a)
+  res === until true (one a)
 
 -- | This test replaces all leaves with zeros, logging their qty/asset pair into a `Writer`.
 -- It ignores `when/cond` nodes altogether.
@@ -261,7 +261,7 @@ testAmericanPut = script do
 
   -- Exercise `anytime`
   remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t
-  remaining === until (TimeGte $ afterTomorrow) (payoff `or`  zero)
+  remaining === until (TimeGte afterTomorrow) (payoff `or`  zero)
 
   -- Exercise `or`
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
@@ -290,11 +290,11 @@ testAmericanPut = script do
 
   -- You must first exercise the 'outer' `anytime`, and then ...
   remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t
-  remaining === until (TimeGte $ afterTomorrow) (payoff `or` zero)
+  remaining === until (TimeGte afterTomorrow) (payoff `or` zero)
 
   -- ... the inner `or`.
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
-  remaining === until (TimeGte $ afterTomorrow) payoff
+  remaining === until (TimeGte afterTomorrow) payoff
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -56,13 +56,13 @@ testAcquire = script do
   res === when (at tomorrow) (scale two (one a))
 
   res <- f (when (at tomorrow) $ scale two (one a)) tomorrow
-  res === scale two (acquired a)
+  res === when (at tomorrow) (scale two (acquired a))
 
   res <- f (cond (at tomorrow) (one a) (one b)) today
-  res === acquired b
+  res === cond (at tomorrow) (one a) (acquired b)
 
   res <- f (cond (at tomorrow) (one a) (one b)) tomorrow
-  res === acquired a
+  res === cond (at tomorrow) (acquired a) (one b)
 
 {- FIXME: confirm if this test makes sense; it broke when we changed observable with inequality
   res <- f (when (O.TimeGte today) (when (O.TimeGte tomorrow) (one a)) ) tomorrow
@@ -70,7 +70,7 @@ testAcquire = script do
 -}
 
   res <- f (when (TimeGte today) (when (TimeGte tomorrow) (one a)) ) tomorrow
-  res === acquired a
+  res === when (TimeGte today) (when (TimeGte tomorrow) (acquired a))
 
   res <- f (one a `or` one b) today
   res === acquired a `or` acquired b
@@ -221,13 +221,14 @@ testEuropeanCall = script do
   t <- getDate
 
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t
-  remaining === payoff
+  remaining === when (at tomorrow) payoff
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
   pending === pure (2.0, a)
 
 -- Knock-in tomorrow
+testAmericanPut : Script ()
 testAmericanPut = script do
   let strike = 30.0
       payoff = scale (O.pure strike - O.observe "spot") (one a)
@@ -322,7 +323,7 @@ testFloatingRateNote = script do
   remaining === frn
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 01
-  remaining === innerFrn -- this should apparently not be the case, but rather remaining === frn
+  remaining === frn
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 frn $ date 2022 Mar 10
   remaining === Zero


### PR DESCRIPTION
This attemps to resolve #49 

I've adjusted the behaviour of `acquire'` so that it respecst `Until` (i.e. I can't acquire something that has already expired).

This breaks the test in `Test/Lifecycle.daml:297`. Need to think about whether we should change that test to make it pass, and whether it's semantically correct.

Note @matteolimberto-da  I removed your FRN `Until` test; it overlaps with the knockout option tests.