### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There is a dependency on [daml-ctl](https://github.com/digital-asset/daml-ctl).
 
 # Building
 
-First off, you need to build [daml-ctl](https://github.com/digital-asset/daml-ctl) and drop the resulting `daml-ctl-x.x.x.dar` in `lib/`.
+First off, you need to fetch [daml-ctl](https://github.com/digital-asset/daml-ctl/releases) and drop  in `lib/`.
 
 You can then build a release version (no tests in the `*.dar`) by running `daml build` in the root directory, or a dev version that includes test from `test`.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,7 +5,7 @@ This document contains upgrade instructions for major (and other significant) ve
 ## 2.0.0
 
 * The SDK verison is now ≥ 2.0
-* The dependency [daml-ctl](https://github.com/digital-asset/daml-ctl) is no longer a git-submodule. You need to download it from it's github page and drop into `lib/`. Take care if building from source that the symlinks `daml/Daml` and `test/daml/Daml` are removed, and `daml-ctl` in the root dir also.
+* The dependency [daml-ctl](https://github.com/digital-asset/daml-ctl) is no longer a git-submodule. You need to [download it](https://github.com/digital-asset/daml-ctl/releases) and drop into `lib/`. Take care if building from source that the symlinks `daml/Daml` and `test/daml/Daml` are removed, and `daml-ctl` in the root dir also.
 * `Claim f t x a` now becomes `Claim t x a`, which replaces `Claim.Serializable`. i.e. it does away with `{de}serialize` altogether. You'll probably need to update your function signatures, although implementations should stay the same.
 * As result of the above, infix notation is broken so you can no longer write e.g.
 


### PR DESCRIPTION
Some more changes clarifying that you don't need to build `daml-ctl` from source.