### PR TITLE
Lifecycle.expire prunes Until when condition is True. Fix #49

### DIFF
--- a/daml/ContingentClaims/Financial.daml
+++ b/daml/ContingentClaims/Financial.daml
@@ -58,8 +58,11 @@ bermudan [t] c = european t c
 bermudan (t :: ts) c = when (at t) (c `or` bermudan ts c)
 
 -- | American option (knock-in). The lead parameter is the first possible acquisition date.
-american : t -> t -> Claim t x a -> Claim t x a
-american t maturity payoff = Anytime ((>=) t) $ Until (at maturity) (payoff `or` zero)
+-- [ML] This is not correct from a valuation perspective, if we want to use an until block then
+-- it should be Until ( t > maturity). The best approximation at the moment for the case of Dates
+-- is to use ( t >= maturity + 1 day)
+american : Date -> Date -> Claim Date x a -> Claim Date x a
+american start maturity payoff = Anytime ((>=) start) $ Until (at $ succ maturity) (payoff `or` zero)
   where (>=) = at
 
 -- | Asset swap on specific fixing dates `[t]`. For example:

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -17,7 +17,7 @@ module ContingentClaims.Lifecycle (
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..), compare)
 import ContingentClaims.Observation qualified as Observation
-import ContingentClaims.Util.Recursion (apoCataM)
+import ContingentClaims.Util.Recursion (apoCataM, apoCataM2)
 import ContingentClaims.Util (pruneZeros')
 import Daml.Control.Recursion (project, embed, distApo)
 import Daml.Control.Monad.Trans.Writer (WriterT, runWriterT)
@@ -89,6 +89,9 @@ acquire' spot (Cond obs c c') = do
 acquire' spot (Anytime obs c) = do
   predicate <- compare spot obs
   pure $ AnytimeF obs if predicate then Right c else Left c
+acquire' spot (Until obs c) = do
+  predicate <- compare spot obs
+  pure $ UntilF obs if predicate then Left c else Right c
 acquire' _ other = pure $ Right <$> project other
 
 -- | Evaluate any observables in `Scale` nodes, accumulating scale factors
@@ -141,27 +144,17 @@ exercise' (elector, election) (isBearer, f@(Anytime _ c)) =
   if elector == isBearer && election == c then Right . (isBearer, ) <$> project c
                                           else Left <$> project f
 exercise' _ (isBearer, other) = Right . (isBearer, ) <$> project other
-
+   
 -- | Replace any subtrees that have expired with `Zero`s.
 expire : (Ord t, Eq a, Monad m) => (a -> t -> m Decimal) -> C t a -> t -> m (C t a)
-expire spot = runKleisli . apoCataM pruneZeros' acquireThenExpire where
-  acquireThenExpire = fmap (fmap distE)
-                      . fmap join
-                      . fmap (fmap sequence)
-                      . fmap (fmap (fmap (expire' spot)))
-                      . fmap (fmap (fmap embed))
-                      . fmap (fmap tsidE)
-                      $ acquire' spot
-  distE = distApo
-  tsidE f = case sequence_ f of
-    Left _ -> Left (embed (fmap foldE f))
-    Right _ -> Right (fmap foldE f)
-  foldE (Left x) = x
-  foldE (Right x) = x
+expire spot = runKleisli . apoCataM2 (expire' spot) (acquire' spot)
 
--- | Coalgebra for `expire`.
-expire' : (Ord t, Monad m) => (a -> t -> m Decimal) -> C t a -> Kleisli m t (F t a (C t a))
-expire' spot (Until obs c) = do
-  predicate <- compare spot obs
-  if predicate then pure ZeroF else pure $ UntilF obs c
-expire' _ other = pure . project $ other
+-- | Algebra for `expire`.
+expire' : (Ord t, Monad m) => (a -> t -> m Decimal) -> F t a (C t a) -> Kleisli m t (C t a)
+expire' _ (UntilF _ Zero) = pure Zero
+expire' spot (UntilF cond c) = do
+  predicate <- compare spot cond
+  if predicate then pure Zero else pure $ Until cond c
+expire' _ other = pure $ pruneZeros' other
+
+

--- a/daml/ContingentClaims/Util/Recursion.daml
+++ b/daml/ContingentClaims/Util/Recursion.daml
@@ -11,6 +11,7 @@ module ContingentClaims.Util.Recursion (
   , anaM
   , apoM
   , apoCataM
+  , apoCataM2
   , futuM
   , hyloM
   , ghyloM
@@ -53,6 +54,10 @@ futuM' f (Free as) = fmap embed . mapA (futuM' f) $ as
 -- | Specialised lazy re-fold, used by `lifecycle`.
 apoCataM : (Monad m, Traversable f) => (f b -> b) -> (a -> m (f (Either b a))) -> a -> m b
 apoCataM g f a = (fmap g <<< (>>= (mapA (pure ||| apoCataM g f))) <<< f) a
+
+-- | Version of `apoCataM` with a monadic algebra 
+apoCataM2 : (Monad m, Traversable f) => (f b -> m b) -> (a -> m (f (Either b a))) -> a -> m b
+apoCataM2 g f a = ((>>= g) <<< (>>= (mapA (pure ||| apoCataM2 g f))) <<< f) a
 
 -- A modified `hylo` (refold), whith an interleaved monad effect (typically `Update`).
 hyloM : (Monad m, Traversable f) => (f b -> b) -> (a -> m (f a)) -> a -> m b

--- a/daml/ContingentClaims/Util/Recursion.daml
+++ b/daml/ContingentClaims/Util/Recursion.daml
@@ -30,9 +30,8 @@ import Daml.Control.Arrow ((&&&), (|||), (>>>), (<<<), Kleisli(..))
 -- The morphisms ending in 'M' are monadic variants, allowing to interleave e.g. `Update` or `Script`.
 -- `cataM` After Tim Williams' talk, https://www.youtube.com/watch?v=Zw9KeP3OzpU.
 
--- TODO: the two folds can probably be simplified with Traverse.mapA too.
 cataM : (Monad m, Traversable f, Recursive b f) => (f a -> m a) -> b -> m a
-cataM f b = (project >>> fmap (cataM f) >>> ((>>= f) . sequence)) b
+cataM f b = ((>>= f) <<< mapA (cataM f) <<< project) b
 
 paraM : (Monad m, Traversable f, Recursive b f) => (f (b, a) -> m a) -> b -> m a
 paraM f b = (project >>> fmap (runKleisli $ Kleisli pure &&& Kleisli (paraM f)) >>> ((>>= f) . sequence)) b
@@ -52,11 +51,11 @@ futuM' f (Pure a) = futuM f a
 futuM' f (Free as) = fmap embed . mapA (futuM' f) $ as
 
 -- | Specialised lazy re-fold, used by `lifecycle`.
-apoCataM : (Monad m, Traversable f, Corecursive b f) => (f b -> b) -> (a -> m (f (Either b a))) -> a -> m b
+apoCataM : (Monad m, Traversable f) => (f b -> b) -> (a -> m (f (Either b a))) -> a -> m b
 apoCataM g f a = (fmap g <<< (>>= (mapA (pure ||| apoCataM g f))) <<< f) a
 
 -- A modified `hylo` (refold), whith an interleaved monad effect (typically `Update`).
-hyloM : (Traversable f, Monad n) => (f b -> b) -> (a -> n (f a)) -> a -> n b
+hyloM : (Monad m, Traversable f) => (f b -> b) -> (a -> m (f a)) -> a -> m b
 hyloM f g a = (fmap f <<< (>>= mapA (hyloM f g)) <<< g) a
 
 ghyloM : (Comonad w, Traversable f, Monad m, Traversable m, Monad n)

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -85,7 +85,7 @@ testAcquire = script do
   res === until false (acquired a)
 
   res <- f (until true (one a)) today
-  res === until true (acquired a)
+  res === until true (one a)
 
 -- | This test replaces all leaves with zeros, logging their qty/asset pair into a `Writer`.
 -- It ignores `when/cond` nodes altogether.
@@ -260,11 +260,11 @@ testAmericanPut = script do
 
   -- Exercise `anytime`
   remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t
-  remaining === until (TimeGte $ afterTomorrow) (payoff `or`  zero)
+  remaining === until (TimeGte $ succ afterTomorrow) (payoff `or`  zero)
 
   -- Exercise `or`
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
-  remaining === until (TimeGte afterTomorrow) payoff
+  remaining === until (TimeGte $ succ afterTomorrow) payoff
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
@@ -274,9 +274,9 @@ testAmericanPut = script do
   setDate afterTomorrow
   t <- getDate
 
-  -- Expiration at maturity n.b. this means you must *first* exercise & settle *before* expiring.
+  -- Expiration at maturity is a no-op
   remaining <- Lifecycle.expire observe25 option t
-  remaining === zero
+  remaining === option
 
   -- Settlement before exercise has been done is a no-op
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
@@ -289,11 +289,11 @@ testAmericanPut = script do
 
   -- You must first exercise the 'outer' `anytime`, and then ...
   remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t
-  remaining === until (TimeGte $ afterTomorrow) (payoff `or` zero)
+  remaining === until (TimeGte $ succ afterTomorrow) (payoff `or` zero)
 
   -- ... the inner `or`.
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
-  remaining === until (TimeGte $ afterTomorrow) payoff
+  remaining === until (TimeGte $ succ afterTomorrow) payoff
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
@@ -306,9 +306,9 @@ testAmericanPut = script do
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t
   remaining === option -- past maturity; no exercise possible
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
   remaining === option
   pending === []
 
-  remaining <- Lifecycle.expire observe25 remaining t
-  remaining === zero
+  remaining <- Lifecycle.expire observe25 option t
+  remaining === zero -- the Until block is correctly pruned

--- a/test/daml/Test/Pricing.daml
+++ b/test/daml/Test/Pricing.daml
@@ -76,15 +76,16 @@ valueMargrabe = script do
   print formula expect
   multIdentity formula === expect
 
-valueAmerican = script do
-  let formula = fapf USD disc exch t $ american t t' (call APPL 142.50 USD)
-      s = Proc "APPL" (exch APPL USD)
-      k = Const 142.50
-      usd = Proc "USD" (disc USD)
-      τ = "τ_0"
-      expect = Sup t τ (usd t * E (max (s τ - k) aunit * I (Ident τ, Ident t') / usd τ ) t)
-  print formula expect
-  multIdentity formula === expect
+-- [ML] removing these tests as long as we can't model American options
+-- valueAmerican = script do
+--   let formula = fapf USD disc exch t $ american t t' (call APPL 142.50 USD)
+--       s = Proc "APPL" (exch APPL USD)
+--       k = Const 142.50
+--       usd = Proc "USD" (disc USD)
+--       τ = "τ_0"
+--       expect = Sup t τ (usd t * E (max (s τ - k) aunit * I (Ident τ, Ident t') / usd τ ) t)
+--   print formula expect
+--   multIdentity formula === expect
     
 
 -- Check to see that the subscript numbering works


### PR DESCRIPTION
This attemps to resolve https://github.com/digital-asset/contingent-claims/issues/49

`Acquire'` respects `Until` (i.e. I can't acquire something that has already expired) as in @lucianojoublanc-da 's PR.

Make sure that `expire` prunes `Until` nodes when the condition is `True`.

The change breaks the test for the American put. I believe this comes from the fact that the `american` constructor does not work when the time parameter is `Date`. 

If we want to define an American option using Anytime -> Until then it should be defined as 
- Anytime ( t ≥ start ) Until ( t > end ) payoff

However, we don't have access to the > operator. Hence, the closest we can get when using `Date`s is 
- Anytime ( t ≥ start ) Until ( t ≥ **succ** end ) payoff

which is what I have used in `american`

I have the feeling this breaks the pricing formula, which I have commented for now

Next steps:
- use expire' instead of pruneZeros' in Lifecycle.lifecycle --> this way we don't need to call expire to make sure Untils are correctly handled
-  figure out how to fix the valuation formula for American options, which might require introducing the `t > t_0` inequality
- rewrite expire to be eager rather than lazy, so that it can enter `When` conditions to check if the inner contract can be pruned (also in case the condition is `False`)
