### PR TITLE
stop recursion when an election is made

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -177,12 +177,12 @@ exercise' _ _ (isBearer, (s, Give c)) = GiveF . Right . (not isBearer, ) $ (s, c
 exercise' (elector, election) t (isBearer, (s, ors@Or {}))
   | elector /= isBearer = Left <$> project ors
   | Time t /= s = Left <$> project ors
-  | election `elem` project ors = Right . (isBearer,) . (s,) <$> project election
+  | election `elem` project ors = Left <$> project election
   | otherwise = Left <$> project ors
 exercise' (elector, election) t (isBearer, (s, f@(Anytime _ c)))
   | elector /= isBearer = Left <$> project f
   | Time t /= s = Left <$> project f
-  | election == c = Right . (isBearer, ) . (s,) <$> WhenF (TimeGte t) c
+  | election == c = Left <$> WhenF (TimeGte t) c
   | otherwise = Left <$> project f
 exercise' _ _ (isBearer, (s, other)) = Right . (isBearer, ) . (s, ) <$> project other
 


### PR DESCRIPTION
This change fixes a sneaky bug when an `Or` election is made:
- at the moment, the elected sub-tree is automatically flagged as Acquired (by the `Right <$> ...` ) without checking whether any predicate of that node is met or not
- the fix I implemented stops the recursion whenever a choice is made

Pros: no bug
Drawback: the claim might need to be life-cycled immediately after the call to `exercise`

An alternative fix is to run the `acquire'` function on the elected node.

The reason why I did not go for this approach is because I think that the `exercise` function should have as little effect as possible other than just applying an election. Happy to hear your thoughts

