### PR TITLE
Refactor acquire

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -13,21 +13,24 @@ module ContingentClaims.Lifecycle (
   , Result(..)
 ) where
 
-import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..), compare, Inequality(..))
+import ContingentClaims.Claim (Claim(..), ClaimF(..), compare, Inequality(..))
 import ContingentClaims.Observation qualified as Observation
 import ContingentClaims.Util.Recursion (apoCataM)
 import ContingentClaims.Util (pruneZeros', intrinsicAcquisitionTime)
-import Daml.Control.Recursion (project, distApo)
+import Daml.Control.Arrow ((|||),(&&&))
+import Daml.Control.Recursion (project)
 import Daml.Control.Monad.Trans.Writer (WriterT, runWriterT)
 import Daml.Control.Monad.Writer.Class (MonadWriter(..))
 import Daml.Control.Monad.Trans.Class (lift)
+import DA.List (singleton)
 import DA.Traversable (sequence)
-import DA.Foldable (elem)
+import DA.Foldable (elem, foldMap)
 import DA.Optional (fromSomeNote)
 import Prelude hiding (sequence, mapA, exercise, compare, elem)
 
 type C t a = Claim t Decimal a
 type F t a = ClaimF t Decimal a
+type AF t a = F t a (Either (C t a) (t, C t a)) -- acquired claim (in functor form)
 
 -- | Returned from a `lifecycle` operation.
 data Result t a = Result with
@@ -57,17 +60,10 @@ lifecycle spot claim today
   $ (acquisitionTime, claim)
   where
     acquireThenSettle =
-      fmap (fmap (fmap join))
-      . fmap (fmap distE)
-      . fmap join
-      . fmap (fmap sequence)
-      . fmap (fmap (fmap (lifecycle' spot)))
-      . fmap (fmap sequence)
-      . fmap sequence
-      . fmap
-      . fmap lift
-      $ acquire' spot today
-    distE = distApo
+      (lifecycle' spot =<<)
+      . lift
+      . sequence
+      . fmap (sequence . (Prelude.fst &&& acquire' spot today))
     acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
 -- | Evaluate observables and skip branches for which predicates don't hold, calculate the acquisition time of the claim's sub-trees.
@@ -80,46 +76,48 @@ acquire' : (Ord t, Eq a, CanAbort m)
   -> t
   -- ^ the today date
   -> (t, C t a)
-  -- ^ input claim and its acquisition time
-  -> m (Either (C t a) (t, C t a))
-acquire' spot t (s, (When obs c)) = do
+  -- ^ input claim in functor form and its acquisition time
+  -> m (AF t a)
+acquire' spot t (s, When obs c) = do
   predicate <- compare spot obs t
   if predicate then
     case obs of
-      TimeGte sNew -> pure $ Right . (max s sNew, ) $ When obs c
-      other -> pure $ Right . (t, ) $ When (TimeGte t) c  -- if the predicate is non-deterministic, we assume that we are lifecycling at a time `t` corresponding to the first instant the predicate becomes True
+      TimeGte sNew -> pure . WhenF obs $ Right (max s sNew, c)
+      other -> pure . WhenF (TimeGte t) $ Right (t, c)  -- if the predicate is non-deterministic, we assume that we are lifecycling at a time `t` corresponding to the first instant the predicate becomes True
     else
-      pure . Left $ When obs c
-acquire' spot today (s,(Cond obs c c')) = do
+      pure . WhenF obs $ Left c
+acquire' spot today (s, Cond obs c c') = do
   predicate <- compare spot obs s
-  if predicate 
-    then acquire' spot today (s,c)
-    else acquire' spot today (s,c')
-acquire' spot today (_,c@(Anytime obs _)) = do
+  acquire' spot today . (s, ) $ if predicate then c else c'
+acquire' spot today (_, Anytime obs c) = do
   predicate <- compare spot obs today
-  pure $ if predicate then Right (today,c) else Left c  -- the acquisition time of a subcontract of `Anytime` is assumed to be the time at which we lifecycle
-acquire' _ _ (s,other) = pure $ Right (s, other)
+  pure . AnytimeF obs $ if predicate then Right (today,c) else Left c  -- the acquisition time of an Anytime node is assumed to be the time at which we lifecycle
+acquire' _ _ (s, other) = pure $ Right . (s, ) <$> project other
 
 -- | Evaluate any observables in `Scale` nodes, accumulating scale factors top-down.
 -- Log the scale factors with their corresponding leaf values. 
--- Skip `Or` and `Anytime` branches, guaranteeing liveness. 
+-- Stop recursion at `Or` and `Anytime` branches, guaranteeing liveness.
 -- Replace any Ones that can be reached with Zeros.
 lifecycle' : (Ord t, CanAbort m)
         => (a -> t -> m Decimal)
-        -> (Decimal, (t, C t a))
-        -- ^ the input claim, the acquisition time of its sub-trees and the accumulated scaling factor
+        -> (Decimal, (t, AF t a))
+        -- ^ the acquired input claim, its acquisition time and the accumulated scaling factor
         -> WriterT [(Decimal,a)] m (F t a (Either (C t a) ((Decimal, (t, C t a)))))
-lifecycle' _ (qty, (_, One asset)) = do
+lifecycle' _ (qty, (_, OneF asset)) = do
   tell [(qty, asset)]
-  pure $ Right <$> ZeroF
-lifecycle' _ (qty, (s, Give c)) =
-  pure . GiveF $ Right (-qty, (s, c))
-lifecycle' spot (qty, (s, Scale obs c)) = do
+  pure $ ZeroF
+lifecycle' _ (qty, (_, GiveF c)) =
+  pure . GiveF $ (-qty, ) <$> c
+lifecycle' spot (qty, (s, ScaleF obs c)) = do
   k <- lift $ Observation.eval spot obs s
-  pure . ScaleF obs $ Right (k * qty, (s, c))
-lifecycle' _ (_, (_, c@Or{})) = pure $ Left <$> project c
-lifecycle' _ (_, (_, c@(Anytime _ _))) = pure $ Left <$> project c
-lifecycle' _ (qty, (s, other)) = pure $ Right . (qty, ) . (s, ) <$> project other
+  pure . ScaleF obs $ (k * qty, ) <$> c
+lifecycle' _ (_, (_, c@OrF{})) =
+  pure $ stop c
+  where stop = fmap $ Left . (identity ||| Prelude.snd)
+lifecycle' _ (_, (_, c@(AnytimeF _ _))) =
+  pure $ stop c
+  where stop = fmap $ Left . (identity ||| Prelude.snd)
+lifecycle' _ (qty, (_, other)) = pure $ fmap (qty, ) <$> other
 
 --  | Acquire `Anytime` and `Or` nodes, by making an election.
 -- `import` this `qualified`, to avoid clashes with `Prelude.exercise`.
@@ -138,18 +136,14 @@ exercise spot election claim today =
   . (True, ) -- initial election authorizer (`True = bearer`)
   $ (acquisitionTime, claim)
   where
-    acquireThenExercise = fmap (fmap (fmap join))
-                        . fmap (fmap distE)
-                        . fmap (fmap (fmap (exercise' election today)))
-                        . fmap (fmap sequence)
-                        . fmap sequence . fmap
-                        $ acquire' spot today
-    distE = distApo
+    acquireThenExercise =
+      fmap (exercise' election today)
+      . sequence
+      . fmap (sequence . (Prelude.fst &&& acquire' spot today))
     acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
--- | Coalgebra for `exercise`.
--- Resolves `Or` nodes by removing them (keeping elected subtrees).
--- Fixes acquisition time of exercised `Anytime` nodes by replacing them with `When (TimeGte t)`.
+-- Resolve `Or` nodes by removing them (keeping elected subtrees).
+-- Fix acquisition time of exercised `Anytime` nodes by replacing them with `When (TimeGte t)`.
 -- The election consists of a boolean representing the authorizer (`True = bearer`),
 -- and this is compared against available branches of the choice.
 exercise' : (Eq t, Eq a)
@@ -157,21 +151,23 @@ exercise' : (Eq t, Eq a)
   -- ^ the election being made
   -> t
   -- ^ the election date
-  -> (Bool, (t, C t a))
-  -- ^ the input claim, its sub-trees acquisition time and a flag keeping track of who is the entitled to the election (`True = bearer`)
+  -> (Bool, (t, AF t a))
+  -- ^ the acquired claim, its acquisition time and a flag keeping track of who is the entitled to the election (`True = bearer`)
   -> (F t a (Either (C t a) (Bool, (t, C t a))))
-exercise' _ _ (isBearer, (s, Give c)) = GiveF . Right . (not isBearer, ) $ (s, c)
-exercise' (elector, election) t (isBearer, (s, ors@Or {}))
-  | elector /= isBearer = Left <$> project ors
-  | t /= s = Left <$> project ors
-  | election `elem` project ors = Right . (isBearer,) . (s,) <$> project election
-  | otherwise = Left <$> project ors
-exercise' (elector, election) t (isBearer, (s, f@(Anytime _ c)))
-  | elector /= isBearer = Left <$> project f
-  | t /= s = Left <$> project f
-  | election == c = Right . (isBearer, ) . (s,) <$> WhenF (TimeGte t) c
-  | otherwise = Left <$> project f
-exercise' _ _ (isBearer, (s, other)) = Right . (isBearer, ) . (s, ) <$> project other
+exercise' _ _ (isBearer, (_, GiveF c)) = GiveF $ (not isBearer, ) <$> c
+exercise' (elector, election) t (isBearer, (s, ors@OrF {}))
+  | elector /= isBearer = stop ors
+  | (t, election) `elem` elections = Left <$> project election
+  | otherwise = stop ors
+  where stop = fmap $ Left . (identity ||| Prelude.snd)
+        elections = foldMap (foldMap singleton) ors
+exercise' (elector, election) t (isBearer, (s, f@(AnytimeF _ _)))
+  | elector /= isBearer = stop f
+  | (t, election) `elem` elections = Left <$> WhenF (TimeGte t) election
+  | otherwise = stop f
+  where stop = fmap $ Left . (identity ||| Prelude.snd)
+        elections = foldMap (foldMap singleton) f
+exercise' _ _ (isBearer, (_, other)) = fmap (isBearer, ) <$> other
 
 -- | Replace any subtrees that have expired with `Zero`s.
 expire : (Ord t, Eq a, CanAbort m) => (a -> t -> m Decimal) -> C t a -> t -> m (C t a)
@@ -179,17 +175,15 @@ expire spot claim today =
   apoCataM pruneZeros' acquireThenExpire
   $ (acquisitionTime, claim)
   where
-    acquireThenExpire = fmap (fmap distE)
-                      . fmap join
-                      . fmap (fmap sequence)
-                      . fmap (fmap (fmap (expire' spot today)))
-                      $ acquire' spot today
-    distE = distApo
+    acquireThenExpire = 
+      (expire' spot today =<<)
+      . sequence . (Prelude.fst &&& acquire' spot today)
     acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
--- | Coalgebra for `expire`.
-expire' : (Ord t, Monad m) => (a -> t -> m Decimal) -> t -> (t, C t a) -> m (F t a (t, C t a))
-expire' spot t (s, Until obs c) = do
+-- | HIDE
+-- Replace Until nodes with Zero when applicable
+expire' : (Ord t, Monad m) => (a -> t -> m Decimal) -> t -> (t, AF t a) -> m (F t a (Either (C t a) (t, C t a)))
+expire' spot t (s, UntilF obs c) = do
   predicate <- compare spot obs t
-  if predicate then pure ZeroF else pure $ UntilF obs (s, c)
-expire' _ _ (s, other) = pure $ (s, ) <$> project other
+  if predicate then pure ZeroF else pure $ UntilF obs c
+expire' _ _ (s, other) = pure other

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -30,7 +30,6 @@ import Prelude hiding (sequence, mapA, exercise, compare, elem)
 
 type C t a = Claim t Decimal a
 type F t a = ClaimF t Decimal a
-type AF t a = F t a (Either (C t a) (t, C t a)) -- acquired claim (in functor form)
 
 -- | Returned from a `lifecycle` operation.
 data Result t a = Result with
@@ -66,6 +65,13 @@ lifecycle spot claim today
       . fmap (sequence . (Prelude.fst &&& acquire' spot today))
     acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
+-- | Helper type used to write apomorphisms on a claim. `Left` is used if unfolding shall not continue. Otherwise, `Right` is used.
+-- The generic type parameter `x` is the carrier of the R-CoAlgebra (typically the sub-tree as well as some additional information).
+type FE t a x = F t a (Either (C t a) x)
+
+-- | Acquired claim (in functor form). The acquisition time is attached to acquired sub-trees.
+type Acquired t a = FE t a (t, C t a)
+
 -- | Evaluate observables and skip branches for which predicates don't hold, calculate the acquisition time of the claim's sub-trees.
 -- Consume `Cond` nodes, leaving the relevant sub-tree.
 -- Replace `When pred c` nodes with `When (TimeGte t) c` if the predicate is non-deterministic and evaluates to True.
@@ -77,7 +83,7 @@ acquire' : (Ord t, Eq a, CanAbort m)
   -- ^ the today date
   -> (t, C t a)
   -- ^ input claim in functor form and its acquisition time
-  -> m (AF t a)
+  -> m (Acquired t a)
 acquire' spot t (s, When obs c) = do
   predicate <- compare spot obs t
   if predicate then
@@ -94,15 +100,18 @@ acquire' spot today (_, Anytime obs c) = do
   pure . AnytimeF obs $ if predicate then Right (today,c) else Left c  -- the acquisition time of an Anytime node is assumed to be the time at which we lifecycle
 acquire' _ _ (s, other) = pure $ Right . (s, ) <$> project other
 
+-- | Carrier type used for `lifecycle`. It consists of a claim, its acquisition time and the accumulated scaling factor.
+type LifecycleCarrier t a = (Decimal, (t, C t a))
+
 -- | Evaluate any observables in `Scale` nodes, accumulating scale factors top-down.
 -- Log the scale factors with their corresponding leaf values. 
 -- Stop recursion at `Or` and `Anytime` branches, guaranteeing liveness.
 -- Replace any Ones that can be reached with Zeros.
 lifecycle' : (Ord t, CanAbort m)
         => (a -> t -> m Decimal)
-        -> (Decimal, (t, AF t a))
+        -> (Decimal, (t, Acquired t a))
         -- ^ the acquired input claim, its acquisition time and the accumulated scaling factor
-        -> WriterT [(Decimal,a)] m (F t a (Either (C t a) ((Decimal, (t, C t a)))))
+        -> WriterT [(Decimal,a)] m (FE t a (LifecycleCarrier t a))
 lifecycle' _ (qty, (_, OneF asset)) = do
   tell [(qty, asset)]
   pure $ ZeroF
@@ -142,6 +151,9 @@ exercise spot election claim today =
       . fmap (sequence . (Prelude.fst &&& acquire' spot today))
     acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
+-- | Carrier type used for `exercise`. It consists of a claim, its acquisition time and a flag keeping track of who is the entitled to the election (`True = bearer`).
+type ExerciseCarrier t a = (Bool, (t, C t a))
+
 -- Resolve `Or` nodes by removing them (keeping elected subtrees).
 -- Fix acquisition time of exercised `Anytime` nodes by replacing them with `When (TimeGte t)`.
 -- The election consists of a boolean representing the authorizer (`True = bearer`),
@@ -151,9 +163,9 @@ exercise' : (Eq t, Eq a)
   -- ^ the election being made
   -> t
   -- ^ the election date
-  -> (Bool, (t, AF t a))
+  -> (Bool, (t, Acquired t a))
   -- ^ the acquired claim, its acquisition time and a flag keeping track of who is the entitled to the election (`True = bearer`)
-  -> (F t a (Either (C t a) (Bool, (t, C t a))))
+  -> FE t a (ExerciseCarrier t a)
 exercise' _ _ (isBearer, (_, GiveF c)) = GiveF $ (not isBearer, ) <$> c
 exercise' (elector, election) t (isBearer, (s, ors@OrF {}))
   | elector /= isBearer = stop ors
@@ -180,9 +192,12 @@ expire spot claim today =
       . sequence . (Prelude.fst &&& acquire' spot today)
     acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
+-- | Carrier type used for `expire`. It consists of a claim and its acquisition time.
+type ExpireCarrier t a = (t, C t a)
+
 -- | HIDE
 -- Replace Until nodes with Zero when applicable
-expire' : (Ord t, Monad m) => (a -> t -> m Decimal) -> t -> (t, AF t a) -> m (F t a (Either (C t a) (t, C t a)))
+expire' : (Ord t, Monad m) => (a -> t -> m Decimal) -> t -> (t, Acquired t a) -> m (FE t a (ExpireCarrier t a))
 expire' spot t (s, UntilF obs c) = do
   predicate <- compare spot obs t
   if predicate then pure ZeroF else pure $ UntilF obs c

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -11,12 +11,12 @@ import ContingentClaims.Lifecycle qualified as Lifecycle
 import ContingentClaims.Observation qualified as O
 import ContingentClaims.Util.Recursion
 import ContingentClaims.Util (intrinsicAcquisitionTime)
-import DA.Action ((>=>))
 import DA.Assert ((===))
 import DA.Date (date, Month(..), toDateUTC, toGregorian)
 import DA.Optional (fromSome)
 import DA.Time (time)
 import DA.Tuple (thd3)
+import Daml.Control.Arrow ((&&&))
 import Daml.Control.Monad.Trans.Writer (runWriterT)
 import Daml.Control.Recursion
 import Daml.Script
@@ -54,11 +54,12 @@ testAcquire = script do
   let acquiredF asset = OneF $ "acquired " <> asset
       acquired asset : C = embed $ acquiredF asset
       g acqTime c t =
-        apoM (Lifecycle.acquire' observe25 t >=> process) (acqTime, c)
-        where process (Left c) = pure $ Left <$> project c
-              process (Right (_, One asset)) = pure $ acquiredF asset
-              process (Right (_, Zero)) = pure $ acquiredF "0"
-              process (Right (s, c)) = pure $ pure . (s, ) <$> project c
+        apoM coalg (acqTime,c)
+        where 
+          coalg = fmap process . (Lifecycle.acquire' observe25 t)
+          process (OneF asset) = acquiredF asset
+          process ZeroF = acquiredF "0"
+          process other = other 
 
       f c = g (fromSome $ intrinsicAcquisitionTime c) c
 
@@ -108,8 +109,13 @@ testAcquire = script do
 testSettle = script do
   let f = fmap (uncurry $ flip Lifecycle.Result)
           . runWriterT
-          . apoM (Lifecycle.lifecycle' observe25)
+          . apoM coalg
           . (1.0, )
+          where
+            coalg = (Lifecycle.lifecycle' observe25) . process
+            process = fmap ( Prelude.fst &&& acquired) -- process the input so that lifecycle' <<< process is a co-algebra that can be used for testing
+            acquired (t,c) = Right . (t, ) <$> project c -- map a claim to an acquired claim
+
 
   Lifecycle.Result{pending, remaining} <- f (today, scale two zero)
   remaining === scale two zero
@@ -146,7 +152,10 @@ testSettle = script do
 
 -- | Replace any `or/anytime` nodes with the elections that have been made.
 testExercise = script do
-  let f election = apo (Lifecycle.exercise' @Date election today) . (True, )
+  let acquired (t,c) = Right . (t, ) <$> project c -- map a claim to an acquired claim
+      process = fmap ( Prelude.fst &&& acquired) -- process the input so that exercise' <<< process is a co-algebra that can be used for testing
+      coalg election today = (Lifecycle.exercise' election today) . process
+      f election = apo (coalg election today) . (True, )
 
   let rem = f (True, one a) (today, one a `or` one b)
   rem === one a
@@ -172,17 +181,20 @@ testExercise = script do
   rem === (anytime true (anytime true (one a)))
 
   -- wrong `Or` election date
-  let rem = apo (Lifecycle.exercise' (True, one a) tomorrow) . (True, ) . (today, ) $ one a `or` one b
+  let rem = apo (coalg (True, one a) tomorrow) . (True, ) . (today, ) $ one a `or` one b
   rem === one a `or` one b
 
   -- wrong `Anytime` election date
   -- This case should never happen in practice as it is prevented by acquire'
-  let rem = apo (Lifecycle.exercise' (True, one a) tomorrow) . (True, ) . (today, ) $ anytime true (one a)
+  let rem = apo (coalg (True, one a) tomorrow) . (True, ) . (today, ) $ anytime true (one a)
   rem === anytime true (one a)
 
 
 testgiveExercise = script do
-  let f election = apo (Lifecycle.exercise' election today) . (True, )
+  let f election = apo (coalg election today) . (True, )
+        where
+          coalg election today = (Lifecycle.exercise' election today) . (fmap ( Prelude.fst &&& acquired))
+          acquired (t,c) = Right . (t, ) <$> project c -- map a claim to an acquired claim
 
   let rem = f (False, one a) (today, anytime true (one a))
   rem === (anytime true (one a))


### PR DESCRIPTION
This is a slight refactoring of the lifecycle code, where I tried to remove some complexity from the process.

Specifically, the `acquire` function would

- project a claim
- evaluate observables and calculate acquisition time of sub-contracts
- consume `Cond` nodes and fix acquisition time of stochastic `When`s
- collect the `Either` and the sub-contracts' acquisition time
- embed the claim ( which is then projected again by the subsequent functions

Following the refactoring, acquire' takes care only of steps 2 and 3 (the "business logic"), which in my opinion simplifies it. It also maintains clear separation between
- the acquisition time of contract `c`
- the acquisition time of any sub-contract of `c`

The exercise, lifecycle and expire functions take as input an "acquired claim" (that is, a claim where we know if we acquire its sub-contracts and at which time).

The change puts us in a position to separate the acquire into an effectful part and a non-effectful one. I am planning to use the latter as part of the valuation semantics (to propagate a potentially-stochastic acquisition time).

Happy to hear your feedback.


