### PR TITLE
remove unused parameter in `mapParams` and `Observation.mapParams`

### DIFF
--- a/daml/ContingentClaims/Claim.daml
+++ b/daml/ContingentClaims/Claim.daml
@@ -100,13 +100,12 @@ until : Inequality t x a -> Claim t x a -> Claim t x a
 until = Until
 
 -- | Replace parameters in an `Claim` with actual values.
-mapParams :  (t -> i)
-          -> (i -> t)
+mapParams :  (i -> t)
           -> (a -> a')
           -> (x -> x')
           -> Claim i x a -> Claim t x' a'
-mapParams ft' ft fk fv =
-  let f = Observation.mapParams ft' fk fv
+mapParams ft fk fv =
+  let f = Observation.mapParams fk fv
   in cata \case
     ZeroF -> Zero
     OneF a -> One $ fk a

--- a/daml/ContingentClaims/Observation.daml
+++ b/daml/ContingentClaims/Observation.daml
@@ -76,15 +76,10 @@ eval doObserve obs t = cataM alg obs
 
 -- | The functor map operation _and_ also map any parameters to keys.
 -- For example, could map the param "spot" to an ISIN code "GB123456789".
--- Also contra-maps time parameter, i.e. from relative time values to absolute ones.
---
--- @ mapParams identity = bimap
---
-mapParams : (t -> i)
-          -> (a -> a')
+mapParams : forall i t a a' x x'. (a -> a')
           -> (x -> x')
           -> Observation i x a -> Observation t x' a'
-mapParams _ g f = cata \case
+mapParams g f = cata \case
   ConstF x -> Const (f x)
   ObserveF key -> Observe (g key)
   AddF (b, b') -> Add (b, b')

--- a/test/daml/Test/Templating.daml
+++ b/test/daml/Test/Templating.daml
@@ -42,7 +42,7 @@ demoTemplate = script do
   let constants : Map.Map Text Decimal = Map.fromList [("k", 99.8)]
       observables : Map.Map Text Text = Map.fromList [("s", "VOD.L"), (ccy, usd)]
       get dict k = fromSomeNote ("failed to template " <> k) (Map.lookup k dict)
-      f = mapParams (`subDate` today) (today `addDays`) (get observables) (get constants)
+      f = mapParams (today `addDays`) (get observables) (get constants)
 
   f aTemplate === when (TimeGte $ date 2021 Jul 15) (scale (O.observe "VOD.L" - O.pure 99.8) (one usd) `or` zero)
 


### PR DESCRIPTION
This PR removes the unused "inverse mapping" `t -> i` from `mapParams`.

In fairness, we could entirely remove the time parameter `t` from `Observation t x a` as the time dependency is always implicit (in `a`) and introduced when the observation is "reified".

I am however unsure whether removing the time parameter from observation is desirable as it is intuitive to have that type parameter there. Moreover, we might wish to introduce observations that depend explicitly on-time going forward.

Happy to hear your thoughts @lucianojoublanc-da.

This is a breaking change.


