### PR TITLE
Tag each payment with the corresponding payment time

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -33,7 +33,7 @@ type F t a = ClaimF t Decimal a
 
 -- | Returned from a `lifecycle` operation.
 data Result t a = Result with
-  pending : [(Decimal, a)]
+  pending : [(t, Decimal, a)]
     -- ^ quantity/asset pairs requiring settlement.
   remaining : C t a
     -- ^ the tree after lifecycled branches have been pruned.
@@ -111,9 +111,9 @@ lifecycle' : (Ord t, CanAbort m)
         => (a -> t -> m Decimal)
         -> (Decimal, (t, Acquired t a))
         -- ^ the acquired input claim, its acquisition time and the accumulated scaling factor
-        -> WriterT [(Decimal,a)] m (FE t a (LifecycleCarrier t a))
-lifecycle' _ (qty, (_, OneF asset)) = do
-  tell [(qty, asset)]
+        -> WriterT [(t, Decimal,a)] m (FE t a (LifecycleCarrier t a))
+lifecycle' _ (qty, (s, OneF asset)) = do
+  tell [(s, qty, asset)]
   pure $ ZeroF
 lifecycle' _ (qty, (_, GiveF c)) =
   pure . GiveF $ (-qty, ) <$> c

--- a/test/daml/Test/FinancialContract.daml
+++ b/test/daml/Test/FinancialContract.daml
@@ -39,14 +39,14 @@ template FinancialContract
                  (_, Quote{close}) <- fetchByKey (ccyOrIsin, t, bearer) -- FIXME: maintainer should be the market data provider
                  pure close
            lifecycleResult <- Lifecycle.lifecycle getSpotRate claims t
-           settlements <- forA lifecycleResult.pending \(quantity, instrument) ->
+           settlements <- forA lifecycleResult.pending \(payDate, quantity, instrument) ->
              create ProposeSettlement
                with
                  payer = counterparty --FIXME: this breaks with a Give Node
                  receiver = bearer
                  instrument
                  quantity
-                 tradeDate = t
+                 tradeDate = payDate
            create this with claims = lifecycleResult.remaining
            return settlements
 

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -123,24 +123,24 @@ testSettle = script do
 
   Lifecycle.Result{pending, remaining} <- f (today, scale two (one a))
   remaining === scale two zero
-  pending === [(2.0, a)]
+  pending === [(today, 2.0, a)]
 
   Lifecycle.Result{pending, remaining} <- f (today, give (one a))
   remaining === give zero
-  pending === [(-1.0 , a)]
+  pending === [(today, -1.0 , a)]
 
   Lifecycle.Result{pending, remaining} <- f (today, scale two (one a `and` one b))
   remaining === scale two (zero `And` zero $ []) -- using the explicit constructor because the smart constructor reduces this to `Zero`
-  pending === [(2.0, a), (2.0, b)]
+  pending === [(today, 2.0, a), (today, 2.0, b)]
 
   Lifecycle.Result{pending, remaining} <- f (today, scale two (one a) `and` scale two (one b))
   remaining === scale two zero `and` scale two zero
-  pending === [(2.0, a), (2.0, b)]
+  pending === [(today, 2.0, a), (today, 2.0, b)]
 
   -- This is a case we don't hit in practice, as it is prevented from acquire'
   Lifecycle.Result{pending, remaining} <- f (today, when false (one a))
   remaining === when false zero
-  pending === pure (1.0, a)
+  pending === pure (today, 1.0, a)
 
   Lifecycle.Result{pending, remaining} <- f (today, anytime true (one a))
   remaining === anytime true (one a)
@@ -216,14 +216,14 @@ testBond = script do
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 (bond [today, tomorrow, afterTomorrow]) t
   remaining === bond [tomorrow, afterTomorrow]
-  pending === [(coupon, a)]
+  pending === [(t, coupon, a)]
 
   setDate tomorrow
   t <- getDate
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === bond [afterTomorrow]
-  pending === [(coupon, a)]
+  pending === [(t, coupon, a)]
 
   -- Check bond coupon doesn't get processed twice
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
@@ -235,7 +235,7 @@ testBond = script do
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
-  pending === [(coupon, a), (principal, a)]
+  pending === [(t, coupon, a), (t, principal, a)]
 
 
 testEuropeanCall = script do
@@ -266,7 +266,7 @@ testEuropeanCall = script do
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
-  pending === pure (2.0, a)
+  pending === pure (t, 2.0, a)
 
 -- Knock-in tomorrow
 testAmericanPut : Script ()
@@ -310,7 +310,7 @@ testAmericanPut = script do
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
-  pending === pure (5.0, a)
+  pending === pure (t, 5.0, a)
 
   -- Scenario 3) at maturity
   setDate afterTomorrow
@@ -339,7 +339,7 @@ testAmericanPut = script do
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
   remaining === zero
-  pending === pure (5.0, a)
+  pending === pure (t, 5.0, a)
 
   -- Scenario 4) after expiration
   setDate $ succ afterTomorrow
@@ -369,7 +369,7 @@ testFloatingRateNote = script do
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Mar 10
   remaining === Zero
-  pending === [(5.0,b)]
+  pending === [(date 2022 Mar 10, 5.0,b)]
 
   pure ()  
 
@@ -393,7 +393,7 @@ testKnockOutBarrier = script do
   -- Payment of the correct amount is made on payment date
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth remaining $ date 2022 Mar 27
   remaining === Zero
-  pending === [(25.0,b)]
+  pending === [(date 2022 Mar 27, 25.0,b)]
 
   -- With a stochastic predicate, if we lifecycle too late (e.g. on the 26th rather than on the 25th) we end up with an incorrect claim
   wrongLifecycleResult <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Mar 26
@@ -407,7 +407,7 @@ testCondLifecycle = script do
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth c today
   remaining === zero
-  pending === [(1.0, a)]
+  pending === [(today, 1.0, a)]
 
   pure ()
 


### PR DESCRIPTION
This is a small but breaking change to the Lifecycle Result.

The `pending` items, which included the `asset` and `quantity` to be settled, now additionally include the corresponding `payment time`.

There are a couple of reasons why I think this makes sense:

- we can model some financial instruments (e.g. bonds, swaps) without storing any tree
  -  we just generate the tree on-the-fly during lifecycling and chop off the payments that have already been made

- it decouples payment granularity vs lifecycle granularity 
  - in the natural gas use-case, this was used to e.g. run the lifecycling once a day but get assets corresponding to an hourly gas flow

- It is a building block if we want the LC function to return all known payments, rather than just the payments falling before or at today

Happy to hear your feedback on this.