### PR TITLE
Correctly calculate intrinsic acquisition time for `Give` and `Until`

### DIFF
--- a/daml/ContingentClaims/Util.daml
+++ b/daml/ContingentClaims/Util.daml
@@ -96,6 +96,8 @@ intrinsicAcquisitionTime (Anytime (TimeGte t) _) = Some t
 intrinsicAcquisitionTime (When (TimeGte t) _) = Some t
 intrinsicAcquisitionTime (And c1 c2 cs) = foldr folder (intrinsicAcquisitionTime c1) (c2 :: cs)
   where folder = liftA2 min . intrinsicAcquisitionTime
+intrinsicAcquisitionTime (Give c) = intrinsicAcquisitionTime c
+intrinsicAcquisitionTime (Until (TimeGte t) c) = intrinsicAcquisitionTime c
 intrinsicAcquisitionTime _ = None
 
 -- | Returns `True` if the the claim has an intrinsic acquisition time, `False` otherwise.

--- a/test/daml/Test/Util.daml
+++ b/test/daml/Test/Util.daml
@@ -57,11 +57,15 @@ testAcquisitionTime = script do
       c6 : C = cond (o1 <= o2) (one a) (one b)
       c7 : C = or (one a) (one b)
       c8 : C = until (o1 <= o2) $ one a
+      c9 : C = until (at today) $ c2
+      c10 : C = give c2
 
   intrinsicAcquisitionTime c5 === None
   intrinsicAcquisitionTime c6 === None
   intrinsicAcquisitionTime c7 === None
   intrinsicAcquisitionTime c8 === None
+  intrinsicAcquisitionTime c9 === Some tomorrow
+  intrinsicAcquisitionTime c10 === Some tomorrow
 
   hasintrinsicAcquisitionTime c1 === True
   hasintrinsicAcquisitionTime c3 === False


### PR DESCRIPTION
One last for today :) This is a non-breaking change for a couple of cases I had forgot to consider when introducing `intrinsicAcquisitionTime`