### PR TITLE
make acquisition time an input to lifecycle functions

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -17,7 +17,7 @@ module ContingentClaims.Lifecycle (
 import ContingentClaims.Claim (Claim(..), ClaimF(..), compare, Inequality(..))
 import ContingentClaims.Observation qualified as Observation
 import ContingentClaims.Util.Recursion (apoCataM)
-import ContingentClaims.Util (pruneZeros', intrinsicAcquisitionTime)
+import ContingentClaims.Util (pruneZeros')
 import Daml.Control.Arrow ((|||),(&&&))
 import Daml.Control.Recursion (project)
 import Daml.Control.Monad.Trans.Writer (WriterT, runWriterT)
@@ -26,7 +26,6 @@ import Daml.Control.Monad.Trans.Class (lift)
 import DA.List (singleton)
 import DA.Traversable (sequence)
 import DA.Foldable (elem, foldMap)
-import DA.Optional (fromSomeNote)
 import Prelude hiding (sequence, mapA, exercise, compare, elem)
 
 type C t a o = Claim t Decimal a o
@@ -56,13 +55,15 @@ data Result t a o = Result with
 -- Results in a function taking today's date, and returning the pruned tree + pending settlements.
 lifecycle : (Ord t, Eq a, CanAbort m)
   => (o -> t -> m Decimal)
-  -- ^ function to evaluate observables 
+  -- ^ function to evaluate observables
   -> C t a o
   -- ^ the input claim
   -> t
+  -- ^ the input claim's acquisition time
+  -> t
   -- ^ the today's date
   -> m (Result t a o)
-lifecycle spot claim today
+lifecycle spot claim acquisitionTime today
   = fmap (uncurry $ flip Result)
   . runWriterT
   . apoCataM pruneZeros' acquireThenSettle
@@ -74,7 +75,6 @@ lifecycle spot claim today
       . lift
       . sequence
       . fmap (sequence . (Prelude.fst &&& acquire' spot today))
-    acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
 -- | Helper type used to write apomorphisms on a claim. `Left` is used if unfolding shall not continue. Otherwise, `Right` is used.
 -- The generic type parameter `x` is the carrier of the R-CoAlgebra (typically the sub-tree as well as some additional information).
@@ -89,7 +89,7 @@ type Acquired t a o = FE t a o (t, C t a o)
 -- This is useless on its own. Composed with other functions, it adds laziness.
 acquire' : (Ord t, Eq a, CanAbort m)
   => (o -> t -> m Decimal)
-  -- ^ function to evaluate observables 
+  -- ^ function to evaluate observables
   -> t
   -- ^ the today date
   -> (t, C t a o)
@@ -115,7 +115,7 @@ acquire' _ _ (s, other) = pure $ Right . (s, ) <$> project other
 type LifecycleCarrier t a o = (Decimal, (t, C t a o))
 
 -- | Evaluate any observables in `Scale` nodes, accumulating scale factors top-down.
--- Log the scale factors with their corresponding leaf values. 
+-- Log the scale factors with their corresponding leaf values.
 -- Stop recursion at `Or` and `Anytime` branches, guaranteeing liveness.
 -- Replace any Ones that can be reached with Zeros.
 lifecycle' : (Ord t, CanAbort m)
@@ -143,15 +143,17 @@ lifecycle' _ (qty, (_, other)) = pure $ fmap (qty, ) <$> other
 -- `import` this `qualified`, to avoid clashes with `Prelude.exercise`.
 exercise : (Ord t, Eq a, Eq o, CanAbort m)
   => (o -> t -> m Decimal)
-  -- ^ function to evaluate observables 
+  -- ^ function to evaluate observables
   -> (Bool, C t a o)
   -- ^ the election being made
   -> C t a o
   -- ^ the input claim
   -> t
+  -- ^ the input claim's acquisition time
+  -> t
   -- ^ the election date
   -> m (C t a o)
-exercise spot election claim today = 
+exercise spot election claim acquisitionTime today =
   apoCataM pruneZeros' acquireThenExercise
   . (True, ) -- initial election authorizer (`True = bearer`)
   $ (acquisitionTime, claim)
@@ -160,7 +162,6 @@ exercise spot election claim today =
       fmap (exercise' election today)
       . sequence
       . fmap (sequence . (Prelude.fst &&& acquire' spot today))
-    acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
 -- | Carrier type used for `exercise`. It consists of a claim, its acquisition time and a flag keeping track of who is the entitled to the election (`True = bearer`).
 type ExerciseCarrier t a o = (Bool, (t, C t a o))
@@ -193,15 +194,14 @@ exercise' (elector, election) t (isBearer, (s, f@(AnytimeF _ _)))
 exercise' _ _ (isBearer, (_, other)) = fmap (isBearer, ) <$> other
 
 -- | Replace any subtrees that have expired with `Zero`s.
-expire : (Ord t, Eq a, CanAbort m) => (o -> t -> m Decimal) -> C t a o -> t -> m (C t a o)
-expire spot claim today =
+expire : (Ord t, Eq a, CanAbort m) => (o -> t -> m Decimal) -> C t a o -> t -> t -> m (C t a o)
+expire spot claim acquisitionTime today =
   apoCataM pruneZeros' acquireThenExpire
   $ (acquisitionTime, claim)
   where
-    acquireThenExpire = 
+    acquireThenExpire =
       (expire' spot today =<<)
       . sequence . (Prelude.fst &&& acquire' spot today)
-    acquisitionTime = fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
 
 -- | Carrier type used for `expire`. It consists of a claim and its acquisition time.
 type ExpireCarrier t a o = (t, C t a o)

--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -44,24 +44,24 @@ data Pending t a = Pending with
 -- | Returned from a `lifecycle` operation.
 data Result t a o = Result with
   pending : [Pending t a]
-    -- ^ payments requiring settlement.
+    -- ^ Payments requiring settlement.
   remaining : C t a o
-    -- ^ the tree after lifecycled branches have been pruned.
+    -- ^ The tree after lifecycled branches have been pruned.
     deriving (Eq, Show)
 
 -- | Collect claims falling due into a list, and return the tree with those nodes pruned.
 -- `m` will typically be `Update`. It is parametrised so it can be run in a `Script`.
 -- The first argument is used to lookup the value of any `Observables`.
--- Results in a function taking today's date, and returning the pruned tree + pending settlements.
+-- Returns the pruned tree + pending settlements up to the provided market time.
 lifecycle : (Ord t, Eq a, CanAbort m)
   => (o -> t -> m Decimal)
-  -- ^ function to evaluate observables
+  -- ^ Function to evaluate observables.
   -> C t a o
-  -- ^ the input claim
+  -- ^ The input claim.
   -> t
-  -- ^ the input claim's acquisition time
+  -- ^ The input claim's acquisition time.
   -> t
-  -- ^ the today's date
+  -- ^ The current market time. This is the time up to which observations are known.
   -> m (Result t a o)
 lifecycle spot claim acquisitionTime today
   = fmap (uncurry $ flip Result)
@@ -91,7 +91,7 @@ acquire' : (Ord t, Eq a, CanAbort m)
   => (o -> t -> m Decimal)
   -- ^ function to evaluate observables
   -> t
-  -- ^ the today date
+  -- ^ the current market time. This is the time up to which observations are known.
   -> (t, C t a o)
   -- ^ input claim in functor form and its acquisition time
   -> m (Acquired t a o)

--- a/daml/ContingentClaims/Util.daml
+++ b/daml/ContingentClaims/Util.daml
@@ -10,8 +10,6 @@ module ContingentClaims.Util (
   , pruneZeros'
   , expiry
   , payoffs
-  , hasintrinsicAcquisitionTime
-  , intrinsicAcquisitionTime
 ) where
 
 import ContingentClaims.Claim (Claim, Claim(..), ClaimF(..), Inequality(..))
@@ -19,7 +17,6 @@ import ContingentClaims.Observation (Observation)
 import Daml.Control.Recursion
 import DA.Foldable (fold, maximum, all)
 import DA.Bifunctor (first)
-import DA.Optional (isSome)
 import Prelude hiding (sum, sequence, mapA, all)
 
 -- | Return the fixing dates of a claim. This does not discriminate between
@@ -83,24 +80,3 @@ pruneZeros' other = embed other
 -- | This avoids requiring the equality type constraint on `a`
 isZero Zero = True
 isZero _ = False
-
--- | Returns the claim's intrinsic acquisition time (IAT) if it exists.
--- It is defined as the time `t` such that, for the purpose of lifecycling and valuation, it is irrelevant whether the contract has been acquired at `t` or at any time `s` before `t`.
--- This check is required as currently the claim's acquisition time is not an input to `lifecycle`, which forces us to work with claims that have an IAT.
--- For instance: 
--- - `Scale obs c` does not have an IAT (as `obs` is evaluated at the claim's acquisition time)
--- - the IAT for `When (TimeGte t) c` is `t`
--- - `When (obs <= 100) c` does not have an IAT, as the acquisition time defines when we start to monitor the observable `obs`
-intrinsicAcquisitionTime : (Ord t) => Claim t x a o -> Optional t
-intrinsicAcquisitionTime (Anytime (TimeGte t) _) = Some t
-intrinsicAcquisitionTime (When (TimeGte t) _) = Some t
-intrinsicAcquisitionTime (And c1 c2 cs) = foldr folder (intrinsicAcquisitionTime c1) (c2 :: cs)
-  where folder = liftA2 min . intrinsicAcquisitionTime
-intrinsicAcquisitionTime (Give c) = intrinsicAcquisitionTime c
-intrinsicAcquisitionTime (Until (TimeGte t) c) = intrinsicAcquisitionTime c
-intrinsicAcquisitionTime _ = None
-
--- | Returns `True` if the the claim has an intrinsic acquisition time, `False` otherwise.
-hasintrinsicAcquisitionTime : (Ord t) => Claim t x a o -> Bool
-hasintrinsicAcquisitionTime = isSome . intrinsicAcquisitionTime
-

--- a/test/daml/Test/FinancialContract.daml
+++ b/test/daml/Test/FinancialContract.daml
@@ -29,6 +29,7 @@ template FinancialContract
     bearer: Party
     counterparty: Party
     claims: Claim Date Decimal Instrument Observable
+    acquisitionTime : Date
   where
     signatory Set.fromList [bearer, counterparty]
 
@@ -39,7 +40,7 @@ template FinancialContract
            let getSpotRate isin t = do
                  (_, Quote{close}) <- fetchByKey (isin, t, bearer) -- FIXME: maintainer should be the market data provider
                  pure close
-           lifecycleResult <- Lifecycle.lifecycle getSpotRate claims t
+           lifecycleResult <- Lifecycle.lifecycle getSpotRate claims acquisitionTime t
            settlements <- forA lifecycleResult.pending \pending ->
              create ProposeSettlement
                with

--- a/test/daml/Test/Initialization.daml
+++ b/test/daml/Test/Initialization.daml
@@ -6,18 +6,26 @@
 module Test.Initialization where
 
 import Daml.Script
-import DA.Date (date, Month(..))
+import DA.Date (date, Month(..), toDateUTC)
 import DA.Time (time)
 import ContingentClaims.Claim
 import Test.FinancialContract
 import ContingentClaims.Financial
 
 createContracts = script do
-  setTime $ time (date 2020 Dec 9) 13 20 30
+  let
+    now = time (date 2020 Dec 9) 13 20 30
+    today = toDateUTC now
+  setTime now
   buyer <- allocatePartyWithHint "Buyer" (PartyIdHint "Buyer")
   -- vod_l  <- submit buyer . createCmd $ Quote "GB00BH4HKS39" (date 2021 Feb 8) 127.36 buyer
-  let mkContract = submit buyer . createCmd . FinancialContract buyer buyer
-  mkContract $ zcb (date 2021 Mar 3) 3400.0 "USD"
-  mkContract $ fixed 100.0 4.0 "GBP" (unrollDates 2021 2025 [Jan, Aug] 5)
-  mkContract $ european (date 2021 Feb 8) (one "GB00BH4HKS39")
+  let mkContract t c = submit buyer . createCmd $ FinancialContract
+        with
+          bearer = buyer
+          counterparty = buyer
+          claims = c
+          acquisitionTime = t
+  mkContract today $  zcb (date 2021 Mar 3) 3400.0 "USD"
+  mkContract today $ fixed 100.0 4.0 "GBP" (unrollDates 2021 2025 [Jan, Aug] 5)
+  mkContract today $ european (date 2021 Feb 8) (one "GB00BH4HKS39")
 

--- a/test/daml/Test/Initialization.daml
+++ b/test/daml/Test/Initialization.daml
@@ -25,7 +25,7 @@ createContracts = script do
           counterparty = buyer
           claims = c
           acquisitionTime = t
-  mkContract today $  zcb (date 2021 Mar 3) 3400.0 "USD"
+  mkContract today $ zcb (date 2021 Mar 3) 3400.0 "USD"
   mkContract today $ fixed 100.0 4.0 "GBP" (unrollDates 2021 2025 [Jan, Aug] 5)
   mkContract today $ european (date 2021 Feb 8) (one "GB00BH4HKS39")
 

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -26,10 +26,10 @@ type F = ClaimF Date Decimal Text Text
 -- | Assets
 [a,b,c] = ["a","b","c"]
 
--- | Dates
-today = date 1970 Jan 1
-tomorrow = succ today
-afterTomorrow = succ tomorrow
+-- | Dates (t0 < t1 < t2)
+t0 = date 1970 Jan 1
+t1 = succ t0
+t2 = succ t1
 
 -- | Observations
 two : O.Observation Date Decimal Text = O.pure 2.0
@@ -51,53 +51,53 @@ setDate = setTime . noon where noon d = time d 12 0 0
 testAcquire = script do
   let acquiredF asset = OneF $ "acquired " <> asset
       acquired asset : C = embed $ acquiredF asset
-      g c acqTime today =
+      g c acqTime t0 =
         apoM coalg (acqTime,c)
         where
-          coalg = fmap process . (Lifecycle.acquire' observe25 today)
+          coalg = fmap process . (Lifecycle.acquire' observe25 t0)
           process (OneF asset) = acquiredF asset
           process ZeroF = acquiredF "0"
           process other = other
 
-  res <- g (one a) today today
+  res <- g (one a) t0 t0
   res === acquired a
 
-  res <- g zero today tomorrow
+  res <- g zero t0 t1
   res === acquired "0"
 
-  res <- g (when (at tomorrow) $ scale two (one a)) today today
-  res === when (at tomorrow) (scale two (one a))
+  res <- g (when (at t1) $ scale two (one a)) t0 t0
+  res === when (at t1) (scale two (one a))
 
-  res <- g (when (at tomorrow) $ scale two (one a)) today tomorrow
-  res === when (at tomorrow) (scale two (acquired a))
+  res <- g (when (at t1) $ scale two (one a)) t0 t1
+  res === when (at t1) (scale two (acquired a))
 
-  res <- g (cond (at tomorrow) (one a) (one b)) today today
+  res <- g (cond (at t1) (one a) (one b)) t0 t0
   res === acquired b
 
-  res <- g (cond (at tomorrow) (one a) (one b)) tomorrow tomorrow
+  res <- g (cond (at t1) (one a) (one b)) t1 t1
   res === acquired a
 
 {- FIXME: confirm if this test makes sense; it broke when we changed observable with inequality
-  res <- f (when (O.TimeGte today) (when (O.TimeGte tomorrow) (one a)) ) tomorrow
-  res === (when (O.TimeGte today) (when (at tomorrow) (one a)) )
+  res <- f (when (O.TimeGte t0) (when (O.TimeGte t1) (one a)) ) t1
+  res === (when (O.TimeGte t0) (when (at t1) (one a)) )
 -}
 
-  res <- g (when (TimeGte today) (when (TimeGte tomorrow) (one a))) today tomorrow
-  res === when (TimeGte today) (when (TimeGte tomorrow) (acquired a))
+  res <- g (when (TimeGte t0) (when (TimeGte t1) (one a))) t0 t1
+  res === when (TimeGte t0) (when (TimeGte t1) (acquired a))
 
-  res <- g (one a `or` one b) today today
+  res <- g (one a `or` one b) t0 t0
   res === acquired a `or` acquired b
 
-  res <- g (anytime true (one a)) today today
+  res <- g (anytime true (one a)) t0 t0
   res === anytime true (acquired a)
 
-  res <- g (anytime false (one a)) today today
+  res <- g (anytime false (one a)) t0 t0
   res === anytime false (one a)
 
-  res <- g (until false (one a)) today today
+  res <- g (until false (one a)) t0 t0
   res === until false (acquired a)
 
-  res <- g (until true (one a)) today today
+  res <- g (until true (one a)) t0 t0
   res === until true (acquired a)
 
 -- | This test replaces all leaves with zeros, logging their qty/asset pair into a `Writer`.
@@ -113,32 +113,32 @@ testSettle = script do
             acquired (t,c) = Right . (t, ) <$> project c -- map a claim to an acquired claim
 
 
-  Lifecycle.Result{pending, remaining} <- f (today, scale two zero)
+  Lifecycle.Result{pending, remaining} <- f (t0, scale two zero)
   remaining === (scale two zero : C)
   pending === []
 
-  Lifecycle.Result{pending, remaining} <- f (today, scale two (one a))
+  Lifecycle.Result{pending, remaining} <- f (t0, scale two (one a))
   remaining === scale two zero
-  pending === [Lifecycle.Pending today 2.0 a]
+  pending === [Lifecycle.Pending t0 2.0 a]
 
-  Lifecycle.Result{pending, remaining} <- f (today, give (one a))
+  Lifecycle.Result{pending, remaining} <- f (t0, give (one a))
   remaining === give zero
-  pending === [Lifecycle.Pending today (-1.0) a]
+  pending === [Lifecycle.Pending t0 (-1.0) a]
 
-  Lifecycle.Result{pending, remaining} <- f (today, scale two (one a `and` one b))
+  Lifecycle.Result{pending, remaining} <- f (t0, scale two (one a `and` one b))
   remaining === scale two (zero `And` zero $ []) -- using the explicit constructor because the smart constructor reduces this to `Zero`
-  pending === [Lifecycle.Pending today 2.0 a, Lifecycle.Pending today 2.0 b]
+  pending === [Lifecycle.Pending t0 2.0 a, Lifecycle.Pending t0 2.0 b]
 
-  Lifecycle.Result{pending, remaining} <- f (today, scale two (one a) `and` scale two (one b))
+  Lifecycle.Result{pending, remaining} <- f (t0, scale two (one a) `and` scale two (one b))
   remaining === scale two zero `and` scale two zero
-  pending === [Lifecycle.Pending today 2.0 a, Lifecycle.Pending today 2.0 b]
+  pending === [Lifecycle.Pending t0 2.0 a, Lifecycle.Pending t0 2.0 b]
 
   -- This is a case we don't hit in practice, as it is prevented from acquire'
-  Lifecycle.Result{pending, remaining} <- f (today, when false (one a))
+  Lifecycle.Result{pending, remaining} <- f (t0, when false (one a))
   remaining === when false zero
-  pending === [Lifecycle.Pending today 1.0 a]
+  pending === [Lifecycle.Pending t0 1.0 a]
 
-  Lifecycle.Result{pending, remaining} <- f (today, anytime true (one a))
+  Lifecycle.Result{pending, remaining} <- f (t0, anytime true (one a))
   remaining === anytime true (one a)
   pending === []
 
@@ -150,58 +150,58 @@ testSettle = script do
 testExercise = script do
   let acquired (t,c) = Right . (t, ) <$> project c -- map a claim to an acquired claim
       process = fmap ( Prelude.fst &&& acquired) -- process the input so that exercise' <<< process is a co-algebra that can be used for testing
-      coalg election today = (Lifecycle.exercise' election today) . process
-      f election = apo (coalg election today) . (True, )
+      coalg election t0 = (Lifecycle.exercise' election t0) . process
+      f election = apo (coalg election t0) . (True, )
 
-  let rem = f (True, one a) (today, one a `or` one b)
+  let rem = f (True, one a) (t0, one a `or` one b)
   rem === (one a : C)
 
-  let rem = f (True, one b) (today, one a `or` one b)
+  let rem = f (True, one b) (t0, one a `or` one b)
   rem === one b
 
-  let rem = f (True, one c) (today, one a `or` one b)
+  let rem = f (True, one c) (t0, one a `or` one b)
   rem === one a `or` one b
 
-  let rem = f (True, one a) (today, anytime true $ one a)
-  rem === When (TimeGte today) (one a)
+  let rem = f (True, one a) (t0, anytime true $ one a)
+  rem === When (TimeGte t0) (one a)
 
   -- n.b. conditions are handled by the `Lifecyle.acquire'` function, so in practice we should never hit this case
-  let rem = f (True, one a) (today, anytime false $ one a)
-  rem === When (TimeGte today) (one a)
+  let rem = f (True, one a) (t0, anytime false $ one a)
+  rem === When (TimeGte t0) (one a)
 
-  let rem = f (True, one c) (today, anytime true $ one a)
+  let rem = f (True, one c) (t0, anytime true $ one a)
   rem === anytime true (one a)
 
   -- nested choice: the outer one must be exercised before the inner!
-  let rem = f (True, one a) (today, anytime true $ anytime true $ one a)
+  let rem = f (True, one a) (t0, anytime true $ anytime true $ one a)
   rem === (anytime true (anytime true (one a)))
 
   -- wrong `Or` election date
-  let rem = apo (coalg (True, one a) tomorrow) . (True, ) . (today, ) $ one a `or` one b
+  let rem = apo (coalg (True, one a) t1) . (True, ) . (t0, ) $ one a `or` one b
   rem === one a `or` one b
 
   -- wrong `Anytime` election date
   -- This case should never happen in practice as it is prevented by acquire'
-  let rem = apo (coalg (True, one a) tomorrow) . (True, ) . (today, ) $ anytime true (one a)
+  let rem = apo (coalg (True, one a) t1) . (True, ) . (t0, ) $ anytime true (one a)
   rem === anytime true (one a)
 
 
 testgiveExercise = script do
-  let f election = apo (coalg election today) . (True, )
+  let f election = apo (coalg election t0) . (True, )
         where
-          coalg election today = (Lifecycle.exercise' election today) . (fmap ( Prelude.fst &&& acquired))
+          coalg election t0 = (Lifecycle.exercise' election t0) . (fmap ( Prelude.fst &&& acquired))
           acquired (t,c) = Right . (t, ) <$> project c -- map a claim to an acquired claim
 
-  let rem = f (False, one a) (today, anytime true (one a))
+  let rem = f (False, one a) (t0, anytime true (one a))
       expected : C = anytime true (one a)
   rem === expected
 
-  let rem = f (False, one a) (today, give (anytime true (one a)))
-      expected : C = give (When (TimeGte today) (one a))
+  let rem = f (False, one a) (t0, give (anytime true (one a)))
+      expected : C = give (When (TimeGte t0) (one a))
   rem === expected
 
-  let rem = f (True, one a) (today, give . give . anytime true $ one a)
-      expected : C = give (give (When (TimeGte today) (one a)))
+  let rem = f (True, one a) (t0, give . give . anytime true $ one a)
+      expected : C = give (give (When (TimeGte t0) (one a)))
   rem === expected
 
 -- | Lifecycle a bond with three fixing dates. Uses ledger time effects.
@@ -210,29 +210,29 @@ testBond = script do
       coupon = principal * 0.015
       bond = fixed principal coupon a
 
-  setDate today
+  setDate t0
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 (bond [today, tomorrow, afterTomorrow]) today t
-  remaining === bond [tomorrow, afterTomorrow]
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 (bond [t0, t1, t2]) t0 t
+  remaining === bond [t1, t2]
   pending === [Lifecycle.Pending t coupon a]
 
-  setDate tomorrow
+  setDate t1
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
-  remaining === bond [afterTomorrow]
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t0 t
+  remaining === bond [t2]
   pending === [Lifecycle.Pending t coupon a]
 
   -- Check bond coupon doesn't get processed twice
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
-  remaining === bond [afterTomorrow]
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t0 t
+  remaining === bond [t2]
   pending === []
 
-  setDate afterTomorrow
+  setDate t2
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t0 t
   remaining === zero
   pending === [Lifecycle.Pending t coupon a, Lifecycle.Pending t principal a]
 
@@ -240,118 +240,119 @@ testBond = script do
 testEuropeanCall = script do
   let strike = 23.0
       payoff = scale (O.observe "spot" - O.pure strike) (one a)
-      option = european tomorrow payoff
+      option = european t1 payoff
       bearer = True
 
   -- Before maturity
-  setDate today
+  setDate t0
   t <- getDate
 
   -- Exercise is a no-op
-  remaining <- Lifecycle.exercise observe25 (bearer, zero) option today t
+  remaining <- Lifecycle.exercise observe25 (bearer, zero) option t0 t
   remaining === option
 
   -- and so is settlement
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t0 t
   remaining === option
   pending === []
 
   -- At maturity
-  setDate tomorrow
+  setDate t1
   t <- getDate
 
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option today t
-  remaining === when (at tomorrow) payoff
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t0 t
+  remaining === when (at t1) payoff
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t0 t
   remaining === zero
   pending === [Lifecycle.Pending t 2.0 a]
 
--- Knock-in tomorrow
+-- | Test for an american option.
+-- The contract is acquired at time `t0` and can be exercised between `t1` and `t2`.
 testAmericanPut : Script ()
 testAmericanPut = script do
   let strike = 30.0
       payoff = scale (O.pure strike - O.observe "spot") (one a)
-      option = american tomorrow afterTomorrow payoff
+      option = american t1 t2 payoff
       bearer = True
 
   -- Scenario 1) Before knock-in
-  setDate today
+  setDate t0
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t0 t
   remaining === option
   pending === []
 
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t0 t
   remaining === option -- not in acquisition range yet
 
   -- Scenario 2) in acquisition range
-  setDate tomorrow
+  setDate t1
   t <- getDate
 
   -- Settlement before exercise is a no-op
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t0 t
   remaining === option
   pending === []
 
   -- So is expiration before maturity
-  remaining <- Lifecycle.expire observe25 remaining today t
+  remaining <- Lifecycle.expire observe25 remaining t0 t
   remaining === option
 
   -- Exercise `anytime`
-  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining today t
-  remaining === when (TimeGte t) (until (TimeGte $ afterTomorrow) (payoff `or`  zero))
+  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t0 t
+  remaining === when (TimeGte t) (until (TimeGte $ t2) (payoff `or`  zero))
 
   -- Exercise `or`
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
-  remaining === when (TimeGte t) (until (TimeGte afterTomorrow) payoff)
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t0 t
+  remaining === when (TimeGte t) (until (TimeGte t2) payoff)
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t0 t
   remaining === zero
   pending === [Lifecycle.Pending t 5.0 a]
 
   -- Scenario 3) at maturity
-  setDate afterTomorrow
+  setDate t2
   t <- getDate
 
   -- Expiration at maturity n.b. this means you must *first* exercise & settle *before* expiring.
-  remaining <- Lifecycle.expire observe25 option today t
+  remaining <- Lifecycle.expire observe25 option t0 t
   remaining === zero
 
   -- Settlement before exercise has been done is a no-op
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t0 t
   remaining === option
   pending === []
 
   -- Trying to exercise inner `or` before `anytime` won't work.
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t0 t
   remaining === option
 
   -- You must first exercise the 'outer' `anytime`, and then ...
-  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining today t
-  remaining === when (TimeGte t) (until (TimeGte $ afterTomorrow) (payoff `or` zero))
+  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t0 t
+  remaining === when (TimeGte t) (until (TimeGte $ t2) (payoff `or` zero))
 
   -- ... the inner `or`.
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
-  remaining === when (TimeGte t) (until (TimeGte $ afterTomorrow) payoff)
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t0 t
+  remaining === when (TimeGte t) (until (TimeGte $ t2) payoff)
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t0 t
   remaining === zero
   pending === [Lifecycle.Pending t 5.0 a]
 
   -- Scenario 4) after expiration
-  setDate $ succ afterTomorrow
+  setDate $ succ t2
   t <- getDate
 
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option today t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t0 t
   remaining === option -- past maturity; no exercise possible
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t0 t
   remaining === option
   pending === []
 
-  remaining <- Lifecycle.expire observe25 remaining today t
+  remaining <- Lifecycle.expire observe25 remaining t0 t
   remaining === zero
 
 -- | Ensure that acquisition time is propagated correctly (deterministic time)
@@ -406,9 +407,9 @@ testCondLifecycle = script do
   let c = When true $ Cond true (One a) (One b)
       expected : C = zero
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth c today today
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth c t0 t0
   remaining === expected
-  pending === [Lifecycle.Pending today 1.0 a]
+  pending === [Lifecycle.Pending t0 1.0 a]
 
   pure ()
 

--- a/test/daml/Test/Lifecycle.daml
+++ b/test/daml/Test/Lifecycle.daml
@@ -10,10 +10,8 @@ import ContingentClaims.Financial (fixed, european, american)
 import ContingentClaims.Lifecycle qualified as Lifecycle
 import ContingentClaims.Observation qualified as O
 import ContingentClaims.Util.Recursion
-import ContingentClaims.Util (intrinsicAcquisitionTime)
 import DA.Assert ((===))
 import DA.Date (date, Month(..), toDateUTC, toGregorian)
-import DA.Optional (fromSome)
 import DA.Time (time)
 import DA.Tuple (thd3)
 import Daml.Control.Arrow ((&&&))
@@ -33,7 +31,7 @@ today = date 1970 Jan 1
 tomorrow = succ today
 afterTomorrow = succ tomorrow
 
--- | Observations 
+-- | Observations
 two : O.Observation Date Decimal Text = O.pure 2.0
 
 -- | Functions performing observations
@@ -53,32 +51,30 @@ setDate = setTime . noon where noon d = time d 12 0 0
 testAcquire = script do
   let acquiredF asset = OneF $ "acquired " <> asset
       acquired asset : C = embed $ acquiredF asset
-      g acqTime c t =
+      g c acqTime today =
         apoM coalg (acqTime,c)
-        where 
-          coalg = fmap process . (Lifecycle.acquire' observe25 t)
+        where
+          coalg = fmap process . (Lifecycle.acquire' observe25 today)
           process (OneF asset) = acquiredF asset
           process ZeroF = acquiredF "0"
-          process other = other 
+          process other = other
 
-      f c = g (fromSome $ intrinsicAcquisitionTime c) c
-
-  res <- g today (one a) today
+  res <- g (one a) today today
   res === acquired a
 
-  res <- g today zero tomorrow
+  res <- g zero today tomorrow
   res === acquired "0"
 
-  res <- f (when (at tomorrow) $ scale two (one a)) today
+  res <- g (when (at tomorrow) $ scale two (one a)) today today
   res === when (at tomorrow) (scale two (one a))
 
-  res <- f (when (at tomorrow) $ scale two (one a)) tomorrow
+  res <- g (when (at tomorrow) $ scale two (one a)) today tomorrow
   res === when (at tomorrow) (scale two (acquired a))
 
-  res <- g today (cond (at tomorrow) (one a) (one b)) today
+  res <- g (cond (at tomorrow) (one a) (one b)) today today
   res === acquired b
 
-  res <- g tomorrow (cond (at tomorrow) (one a) (one b)) tomorrow
+  res <- g (cond (at tomorrow) (one a) (one b)) tomorrow tomorrow
   res === acquired a
 
 {- FIXME: confirm if this test makes sense; it broke when we changed observable with inequality
@@ -86,22 +82,22 @@ testAcquire = script do
   res === (when (O.TimeGte today) (when (at tomorrow) (one a)) )
 -}
 
-  res <- f (when (TimeGte today) (when (TimeGte tomorrow) (one a)) ) tomorrow
+  res <- g (when (TimeGte today) (when (TimeGte tomorrow) (one a))) today tomorrow
   res === when (TimeGte today) (when (TimeGte tomorrow) (acquired a))
 
-  res <- g today (one a `or` one b) today
+  res <- g (one a `or` one b) today today
   res === acquired a `or` acquired b
 
-  res <- f (anytime true (one a)) today
+  res <- g (anytime true (one a)) today today
   res === anytime true (acquired a)
 
-  res <- f (anytime false (one a)) today
+  res <- g (anytime false (one a)) today today
   res === anytime false (one a)
 
-  res <- g today (until false (one a)) today
+  res <- g (until false (one a)) today today
   res === until false (acquired a)
 
-  res <- g today (until true (one a)) today
+  res <- g (until true (one a)) today today
   res === until true (acquired a)
 
 -- | This test replaces all leaves with zeros, logging their qty/asset pair into a `Writer`.
@@ -217,26 +213,26 @@ testBond = script do
   setDate today
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 (bond [today, tomorrow, afterTomorrow]) t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 (bond [today, tomorrow, afterTomorrow]) today t
   remaining === bond [tomorrow, afterTomorrow]
   pending === [Lifecycle.Pending t coupon a]
 
   setDate tomorrow
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
   remaining === bond [afterTomorrow]
   pending === [Lifecycle.Pending t coupon a]
 
   -- Check bond coupon doesn't get processed twice
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
   remaining === bond [afterTomorrow]
   pending === []
 
   setDate afterTomorrow
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
   remaining === zero
   pending === [Lifecycle.Pending t coupon a, Lifecycle.Pending t principal a]
 
@@ -252,11 +248,11 @@ testEuropeanCall = script do
   t <- getDate
 
   -- Exercise is a no-op
-  remaining <- Lifecycle.exercise observe25 (bearer, zero) option t
+  remaining <- Lifecycle.exercise observe25 (bearer, zero) option today t
   remaining === option
 
   -- and so is settlement
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
   remaining === option
   pending === []
 
@@ -264,10 +260,10 @@ testEuropeanCall = script do
   setDate tomorrow
   t <- getDate
 
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option today t
   remaining === when (at tomorrow) payoff
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
   remaining === zero
   pending === [Lifecycle.Pending t 2.0 a]
 
@@ -283,11 +279,11 @@ testAmericanPut = script do
   setDate today
   t <- getDate
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
   remaining === option
   pending === []
 
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
   remaining === option -- not in acquisition range yet
 
   -- Scenario 2) in acquisition range
@@ -295,23 +291,23 @@ testAmericanPut = script do
   t <- getDate
 
   -- Settlement before exercise is a no-op
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
   remaining === option
   pending === []
 
   -- So is expiration before maturity
-  remaining <- Lifecycle.expire observe25 remaining t
+  remaining <- Lifecycle.expire observe25 remaining today t
   remaining === option
 
   -- Exercise `anytime`
-  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t
+  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining today t
   remaining === when (TimeGte t) (until (TimeGte $ afterTomorrow) (payoff `or`  zero))
 
   -- Exercise `or`
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
   remaining === when (TimeGte t) (until (TimeGte afterTomorrow) payoff)
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
   remaining === zero
   pending === [Lifecycle.Pending t 5.0 a]
 
@@ -320,27 +316,27 @@ testAmericanPut = script do
   t <- getDate
 
   -- Expiration at maturity n.b. this means you must *first* exercise & settle *before* expiring.
-  remaining <- Lifecycle.expire observe25 option t
+  remaining <- Lifecycle.expire observe25 option today t
   remaining === zero
 
   -- Settlement before exercise has been done is a no-op
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option today t
   remaining === option
   pending === []
 
   -- Trying to exercise inner `or` before `anytime` won't work.
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
   remaining === option
 
   -- You must first exercise the 'outer' `anytime`, and then ...
-  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining t
+  remaining <- Lifecycle.exercise observe25 (bearer, remaining.claim) remaining today t
   remaining === when (TimeGte t) (until (TimeGte $ afterTomorrow) (payoff `or` zero))
 
   -- ... the inner `or`.
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) remaining today t
   remaining === when (TimeGte t) (until (TimeGte $ afterTomorrow) payoff)
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
   remaining === zero
   pending === [Lifecycle.Pending t 5.0 a]
 
@@ -348,33 +344,34 @@ testAmericanPut = script do
   setDate $ succ afterTomorrow
   t <- getDate
 
-  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t
+  remaining <- Lifecycle.exercise observe25 (bearer, payoff) option today t
   remaining === option -- past maturity; no exercise possible
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining t
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 remaining today t
   remaining === option
   pending === []
 
-  remaining <- Lifecycle.expire observe25 remaining t
+  remaining <- Lifecycle.expire observe25 remaining today t
   remaining === zero
 
 -- | Ensure that acquisition time is propagated correctly (deterministic time)
 testFloatingRateNote = script do
-  let 
+  let
+    acquisitionDate = date 2022 Mar 01
     innerFrn = Scale (O.Observe a) $ When (TimeGte $ date 2022 Mar 10) $ One b
     frn = When (TimeGte $ date 2022 Mar 05) innerFrn
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Feb 28
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn acquisitionDate $ date 2022 Feb 28
   remaining === frn
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Mar 07
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn acquisitionDate $ date 2022 Mar 07
   remaining === frn
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Mar 10
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn acquisitionDate $ date 2022 Mar 10
   remaining === Zero
   pending === [Lifecycle.Pending (date 2022 Mar 10) 5.0 b]
 
-  pure ()  
+  pure ()
 
 -- | Ensure that acquisition time is propagated correctly (stochastic time)
 testKnockOutBarrier = script do
@@ -385,31 +382,31 @@ testKnockOutBarrier = script do
     frn = When (at start) $ When inequality innerFrn
 
   -- Predicate is False, contract should be unchanged
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Mar 01
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn start $ date 2022 Mar 01
   remaining === frn
 
   -- Predicate becomes True and `When pred` should be replaced by `When (TimeGte τ)`
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Mar 25
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth frn start $ date 2022 Mar 25
   remaining === When (at start) (When (TimeGte $ date 2022 Mar 25) innerFrn)
   pending === []
 
   -- Payment of the correct amount is made on payment date
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth remaining $ date 2022 Mar 27
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth remaining start $ date 2022 Mar 27
   remaining === Zero
   pending === [Lifecycle.Pending (date 2022 Mar 27) 25.0 b]
 
   -- With a stochastic predicate, if we lifecycle too late (e.g. on the 26th rather than on the 25th) we end up with an incorrect claim
-  wrongLifecycleResult <- Lifecycle.lifecycle observeDayOfMonth frn $ date 2022 Mar 26
+  wrongLifecycleResult <- Lifecycle.lifecycle observeDayOfMonth frn start $ date 2022 Mar 26
   wrongLifecycleResult.remaining === When (at start) (When (TimeGte $ date 2022 Mar 26) innerFrn)
 
   pure ()
 
--- | Ensure that `Cond` nodes are lifecycled appropriately 
+-- | Ensure that `Cond` nodes are lifecycled appropriately
 testCondLifecycle = script do
   let c = When true $ Cond true (One a) (One b)
       expected : C = zero
 
-  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth c today
+  Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observeDayOfMonth c today today
   remaining === expected
   pending === [Lifecycle.Pending today 1.0 a]
 

--- a/test/daml/Test/Util.daml
+++ b/test/daml/Test/Util.daml
@@ -14,7 +14,7 @@ import DA.Assert ((===))
 import DA.Date
 import Daml.Script
 import Prelude hiding (enumerate, length, or, and, (<=))
-import ContingentClaims.Util (hasintrinsicAcquisitionTime, intrinsicAcquisitionTime, expiry, payoffs)
+import ContingentClaims.Util (expiry, payoffs)
 
 type C = Claim Date Decimal Text Text
 
@@ -28,58 +28,3 @@ utils = script do
 
   expiry (forward t multiplier (one "USD")) === Some t
   payoffs (forward t multiplier (one "USD")) === [(multiplier, "USD")]
-
--- | Test `intrinsicAcquisitionTime` and `hasintrinsicAcquisitionTime`
-testAcquisitionTime = script do
-
-  let [a,b] = ["a","b"]
-      today = date 1970 Jan 1
-      tomorrow = succ today
-      o1 = O.observe a
-      o2 = O.observe b
-
-  intrinsicAcquisitionTime (zero : C) === None
-  intrinsicAcquisitionTime (one a : C) === None
-
-  let c1 = when (at today) $ one a
-      c2 = anytime (at tomorrow) $ one b
-      c3 : C = when (o1 <= o2) $ one a
-      c4 : C = anytime (o1 <= o2) (one a)
-
-  intrinsicAcquisitionTime c1 === Some today
-  intrinsicAcquisitionTime c2 === Some tomorrow
-  intrinsicAcquisitionTime c3 === None
-  intrinsicAcquisitionTime c4 === None
-  intrinsicAcquisitionTime (and c1 c2) === Some today
-  intrinsicAcquisitionTime (mconcat [c1, c2, c3]) === None
-
-  let c5 : C = scale o1 $ one a
-      c6 : C = cond (o1 <= o2) (one a) (one b)
-      c7 : C = or (one a) (one b)
-      c8 : C = until (o1 <= o2) $ one a
-      c9 : C = until (at tomorrow) $ c1
-      c10 : C = give c2
-
-  intrinsicAcquisitionTime c5 === None
-  intrinsicAcquisitionTime c6 === None
-  intrinsicAcquisitionTime c7 === None
-  intrinsicAcquisitionTime c8 === None
-  intrinsicAcquisitionTime c9 === Some today
-  intrinsicAcquisitionTime c10 === Some tomorrow
-
-  hasintrinsicAcquisitionTime c1 === True
-  hasintrinsicAcquisitionTime c3 === False
-
-  
-
-
-
-
-
-
-      
-
-
-
-
-


### PR DESCRIPTION
- make acquisition time an input to lifecycle functions
- remove intrinsic acquisition time

Happy to hear your thoughts on this PR. 

In my opinion it has the advantage of 
- removing complexity from the library (no `intrinsicAcquisitionTime`)
- making all contracts well-defined (e.g. `Scale ...`, `Or ...`)

If you are happy with this change, it might be a good time to push it as we already broke the API