### PR TITLE
Handle degenerate case when provided acquisition time > today

### DIFF
--- a/daml/ContingentClaims/Lifecycle.daml
+++ b/daml/ContingentClaims/Lifecycle.daml
@@ -62,6 +62,7 @@ lifecycle : (Ord t, Eq a, CanAbort m)
   -> t
   -- ^ The current market time. This is the time up to which observations are known.
   -> m (Result t a o)
+lifecycle _ claim acquisitionTime today | acquisitionTime > today = pure Result with pending = []; remaining = claim
 lifecycle spot claim acquisitionTime today
   = fmap (uncurry $ flip Result)
   . runWriterT
@@ -95,6 +96,7 @@ acquire' : (Ord t, Eq a, CanAbort m)
   -> (t, C t a o)
   -- ^ input claim in functor form and its acquisition time
   -> m (Acquired t a o)
+acquire' _ t (s,_) | s > t = abort "Acquisition time of contract is after the provided market time."
 acquire' spot t (s, When obs c) = do
   predicate <- compare spot obs t
   if predicate then
@@ -154,6 +156,7 @@ exercise : (Ord t, Eq a, Eq o, CanAbort m)
   -> t
   -- ^ the election date
   -> m (C t a o)
+exercise _ _ claim acquisitionTime today | acquisitionTime > today = pure claim
 exercise spot election claim acquisitionTime today =
   apoCataM pruneZeros' acquireThenExercise
   . (True, ) -- initial election authorizer (`True = bearer`)


### PR DESCRIPTION
This PR covers the degenerate case where a user tries to lifecycle a contract before its acquisition time