### PR TITLE
Introduce revisited valuation semantics

### DIFF
--- a/daml/ContingentClaims/Math/AcquisitionTime.daml
+++ b/daml/ContingentClaims/Math/AcquisitionTime.daml
@@ -11,25 +11,31 @@ import ContingentClaims.Claim hiding (compare,(<=))
 import Prelude hiding (Time, sequence, mapA, const)
 
 -- | Acquisition time of a contract in the context of the valuation semantics.
--- It is either a deterministic time (`Time t`) or it is defined based on a set of `Inequality`. In the latter case, the acquisition time is defined as the first instant when all of the inequalities are met, with the inequalities generally being of stochastic nature.
--- [ML] it is not obvious if we actually need the (Time t) part as it could simply be expressed in terms of the deterministic inequality (TimeGte t)
+-- It is either a deterministic time (`Time t`) or it is defined based on a list of `Inequality`.
+-- For inequalities [i_1, i_2, ..., i_N], the acquisition time is defined as the first instant `t` for which there exist times `t_1 ≤ t_2 ≤ ... ≤ t_N ≤ t` such that `t_k` verifies `i_k` for each `k`.
+-- In both cases, the time `t` is a stopping time in the mathematical sense.
+-- [ML] it is not obvious if we actually need the (Time t) part as it could simply be expressed in terms of the deterministic inequality (TimeGte t).
+-- [ML] we should rewrite definitions using `inf` instead of "first instant".
 data AcquisitionTime t x o
   = Time t
+    -- ^ Acquisition at time `t`.
   | AtInequality { inequalities : [Inequality t x o] }
+    -- ^ Acquisition when inequalities are verified. The order of the inequalities matters (see definition above).
   | Never
+    -- ^ Acquisition never happens.
   deriving (Eq,Show)
 
--- | Given an inequality and an acquisition time τ1, it returns the smallest acquisition time τ2 such that
--- - the inequality is verified at τ2
--- - τ2 >= τ1
--- The name `extend` comes from the fact that we are extending the set of inequality constraints that need to be verified
+-- | Given an inequality and an acquisition time τ1, it returns the acquisition time τ2 corresponding to the first instant such that
+-- - the inequality is verified
+-- - τ2 ≥ τ1
+-- The name `extend` comes from the fact that we are extending the set of inequality constraints that need to be verified.
 extend : (Ord t) => Inequality t x o -> AcquisitionTime t x o -> AcquisitionTime t x o
 extend _ Never = Never
 extend (TimeGte s) (Time t) = Time $ max s t
-extend (TimeLte s) (Time t) | s > t = Time t
+extend (TimeLte s) (Time t) | s >= t = Time t
 extend (TimeLte s) (Time t) = Never
-extend ineq@(Lte _) (Time t) = AtInequality [ineq, TimeGte t]
-extend ineq (AtInequality ineqs) = AtInequality $ ineq :: ineqs
+extend ineq@(Lte _) (Time t) = AtInequality [TimeGte t, ineq]
+extend ineq (AtInequality ineqs) = AtInequality $ ineqs <> [ineq]
 
 -- | Checks if an acquisition time falls before or at the today date.
 -- `None` is returned if the acquisition time is unknown.

--- a/daml/ContingentClaims/Math/AcquisitionTime.daml
+++ b/daml/ContingentClaims/Math/AcquisitionTime.daml
@@ -1,0 +1,36 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ContingentClaims.Math.AcquisitionTime (
+  AcquisitionTime(..),
+  beforeOrAtToday,
+  extend
+) where
+
+import ContingentClaims.Claim hiding (compare,(<=))
+import Prelude hiding (Time, sequence, mapA, const)
+
+-- | Acquisition time of a contract in the context of the valuation semantics.
+-- It is either a deterministic time (`Time t`) or it is defined based on a set of `Inequality`. In the latter case, the acquisition time is defined as the first instant when all of the inequalities are met, with the inequalities generally being of stochastic nature.
+-- [ML] it is not obvious if we actually need the (Time t) part as it could simply be expressed in terms of the deterministic inequality (TimeGte t)
+data AcquisitionTime t x a
+  = Time t
+  | AtInequality { inequalities : [Inequality t x a] }
+  deriving (Eq,Show)
+
+-- | Given an inequality and an acquisition time τ1, it returns the acquisition time τ2 such that
+-- - the inequality is verified at τ2
+-- - τ2 >= τ1 
+-- The name `extend` comes from the fact that we are extending the set of inequality constraints that need to be verified
+extend : (Ord t) => Inequality t x a -> AcquisitionTime t x a -> AcquisitionTime t x a
+extend (TimeGte s) (Time t) = Time $ max s t
+extend ineq@(Lte _) (Time t) = AtInequality [ineq, TimeGte t]
+extend ineq (AtInequality ineqs) = AtInequality $ ineq :: ineqs
+
+-- | Checks if an acquisition time falls before or at the today date.
+-- `None` is returned if the acquisition time is unknown.
+beforeOrAtToday : (Ord t) => t -> AcquisitionTime t x a -> Optional Bool
+beforeOrAtToday today (Time s) = Some $ s <= today
+beforeOrAtToday today (AtInequality [TimeGte s]) = Some $ s <= today
+beforeOrAtToday today (AtInequality _) = None
+

--- a/daml/ContingentClaims/Math/AcquisitionTime.daml
+++ b/daml/ContingentClaims/Math/AcquisitionTime.daml
@@ -13,16 +13,16 @@ import Prelude hiding (Time, sequence, mapA, const)
 -- | Acquisition time of a contract in the context of the valuation semantics.
 -- It is either a deterministic time (`Time t`) or it is defined based on a set of `Inequality`. In the latter case, the acquisition time is defined as the first instant when all of the inequalities are met, with the inequalities generally being of stochastic nature.
 -- [ML] it is not obvious if we actually need the (Time t) part as it could simply be expressed in terms of the deterministic inequality (TimeGte t)
-data AcquisitionTime t x a
+data AcquisitionTime t x o
   = Time t
-  | AtInequality { inequalities : [Inequality t x a] }
+  | AtInequality { inequalities : [Inequality t x o] }
   deriving (Eq,Show)
 
 -- | Given an inequality and an acquisition time τ1, it returns the acquisition time τ2 such that
 -- - the inequality is verified at τ2
--- - τ2 >= τ1 
+-- - τ2 >= τ1
 -- The name `extend` comes from the fact that we are extending the set of inequality constraints that need to be verified
-extend : (Ord t) => Inequality t x a -> AcquisitionTime t x a -> AcquisitionTime t x a
+extend : (Ord t) => Inequality t x o -> AcquisitionTime t x o -> AcquisitionTime t x o
 extend (TimeGte s) (Time t) = Time $ max s t
 extend ineq@(Lte _) (Time t) = AtInequality [ineq, TimeGte t]
 extend ineq (AtInequality ineqs) = AtInequality $ ineq :: ineqs

--- a/daml/ContingentClaims/Math/AcquisitionTime.daml
+++ b/daml/ContingentClaims/Math/AcquisitionTime.daml
@@ -16,20 +16,25 @@ import Prelude hiding (Time, sequence, mapA, const)
 data AcquisitionTime t x o
   = Time t
   | AtInequality { inequalities : [Inequality t x o] }
+  | Never
   deriving (Eq,Show)
 
--- | Given an inequality and an acquisition time τ1, it returns the acquisition time τ2 such that
+-- | Given an inequality and an acquisition time τ1, it returns the smallest acquisition time τ2 such that
 -- - the inequality is verified at τ2
 -- - τ2 >= τ1
 -- The name `extend` comes from the fact that we are extending the set of inequality constraints that need to be verified
 extend : (Ord t) => Inequality t x o -> AcquisitionTime t x o -> AcquisitionTime t x o
+extend _ Never = Never
 extend (TimeGte s) (Time t) = Time $ max s t
+extend (TimeLte s) (Time t) | s > t = Time t
+extend (TimeLte s) (Time t) = Never
 extend ineq@(Lte _) (Time t) = AtInequality [ineq, TimeGte t]
 extend ineq (AtInequality ineqs) = AtInequality $ ineq :: ineqs
 
 -- | Checks if an acquisition time falls before or at the today date.
 -- `None` is returned if the acquisition time is unknown.
 beforeOrAtToday : (Ord t) => t -> AcquisitionTime t x a -> Optional Bool
+beforeOrAtToday _ Never = Some False
 beforeOrAtToday today (Time s) = Some $ s <= today
 beforeOrAtToday today (AtInequality [TimeGte s]) = Some $ s <= today
 beforeOrAtToday today (AtInequality _) = None

--- a/daml/ContingentClaims/Math/AcquisitionTime.daml
+++ b/daml/ContingentClaims/Math/AcquisitionTime.daml
@@ -1,11 +1,12 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module ContingentClaims.Math.AcquisitionTime (
-  AcquisitionTime(..),
-  beforeOrAtToday,
-  extend
-) where
+module ContingentClaims.Math.AcquisitionTime
+  ( AcquisitionTime(..)
+  , beforeOrAtToday
+  , extend
+  , resolve
+  ) where
 
 import ContingentClaims.Claim (Inequality(..))
 import Prelude hiding (Time, sequence, mapA, const)
@@ -44,4 +45,10 @@ beforeOrAtToday _ Never = Some False
 beforeOrAtToday today (Time s) = Some $ s <= today
 beforeOrAtToday today (AtInequality [TimeGte s]) = Some $ s <= today
 beforeOrAtToday today (AtInequality _) = None
+
+-- | Check if acquisition time is known.
+-- TODO improve for `TimeLte`.
+resolve : AcquisitionTime t x o -> Optional t
+resolve (Time t) = Some t
+resolve _ = None
 

--- a/daml/ContingentClaims/Math/AcquisitionTime.daml
+++ b/daml/ContingentClaims/Math/AcquisitionTime.daml
@@ -5,7 +5,7 @@ module ContingentClaims.Math.AcquisitionTime
   ( AcquisitionTime(..)
   , beforeOrAtToday
   , extend
-  , resolve
+  , isNever
   ) where
 
 import ContingentClaims.Claim (Inequality(..))
@@ -15,8 +15,6 @@ import Prelude hiding (Time, sequence, mapA, const)
 -- It is either a deterministic time (`Time t`) or it is defined based on a list of `Inequality`.
 -- For inequalities [i_1, i_2, ..., i_N], the acquisition time is defined as the first instant `t` for which there exist times `t_1 ≤ t_2 ≤ ... ≤ t_N ≤ t` such that `t_k` verifies `i_k` for each `k`.
 -- In both cases, the time `t` is a stopping time in the mathematical sense.
--- [ML] it is not obvious if we actually need the (Time t) part as it could simply be expressed in terms of the deterministic inequality (TimeGte t).
--- [ML] we should rewrite definitions using `inf` instead of "first instant".
 data AcquisitionTime t x o
   = Time t
     -- ^ Acquisition at time `t`.
@@ -43,12 +41,10 @@ extend ineq (AtInequality ineqs) = AtInequality $ ineqs <> [ineq]
 beforeOrAtToday : (Ord t) => t -> AcquisitionTime t x a -> Optional Bool
 beforeOrAtToday _ Never = Some False
 beforeOrAtToday today (Time s) = Some $ s <= today
-beforeOrAtToday today (AtInequality [TimeGte s]) = Some $ s <= today
 beforeOrAtToday today (AtInequality _) = None
 
--- | Check if acquisition time is known.
--- TODO improve for `TimeLte`.
-resolve : AcquisitionTime t x o -> Optional t
-resolve (Time t) = Some t
-resolve _ = None
-
+-- | Checks if an acquisition time is `Never`.
+-- This is used to avoid requiring the (Eq o) constraint.
+isNever : AcquisitionTime t x a -> Bool
+isNever Never = True
+isNever _ = False

--- a/daml/ContingentClaims/Math/AcquisitionTime.daml
+++ b/daml/ContingentClaims/Math/AcquisitionTime.daml
@@ -7,7 +7,7 @@ module ContingentClaims.Math.AcquisitionTime (
   extend
 ) where
 
-import ContingentClaims.Claim hiding (compare,(<=))
+import ContingentClaims.Claim (Inequality(..))
 import Prelude hiding (Time, sequence, mapA, const)
 
 -- | Acquisition time of a contract in the context of the valuation semantics.

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -1,0 +1,128 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ContingentClaims.Math.Expression (
+  Expr(..),
+  ExprF(..),
+) where
+
+import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..))
+import DA.Foldable
+import DA.Traversable
+import Daml.Control.Recursion
+import Prelude hiding (Time, sequence, mapA, const)
+
+-- | Represents an algebraic expression of a t-adapted stochastic process
+-- t : time parameter
+-- x : state parameter, typically Decimal
+-- a : reference used to identify observables
+-- b : type describing elementary processes
+data Expr t x a b
+  = Const x
+    -- ^ a constant process
+  | Ident t
+    -- ^ a process that takes the value of the time parameter
+  | Proc { name : b }
+    -- ^ an elementary process which we cannot decompose further
+  -- | Sup { lowerBound: t, tau: t, rv : Expr t }
+    -- ^ sup, needs to be reworked using feasible exercise strategies
+  | Sum [Expr t x a b]
+    -- ^ sum
+  | Neg (Expr t x a b)
+    -- ^ negation
+  | Mul (Expr t x a b, Expr t x a b)
+    -- ^ multiplication
+  | Div (Expr t x a b, Expr t x a b)
+    -- ^ division
+  -- | I (Expr t x a b , Expr t x a b)
+    -- ^ indicator function, rework using inequalities
+  | E { process : Expr t x a b, time : AcquisitionTime t x a, filtration : AcquisitionTime t x a }
+    -- ^ conditional expectation of `process(time)` conditioned on the filtration F_`t`
+  deriving (Eq,Show)
+
+-- | Base functor for `Expr`.
+data ExprF t x a b c
+  = ConstF x
+  | IdentF t
+  | ProcF { name : b }
+  -- | Sup { lowerBound: t, tau: t, rv : Expr t }
+  | SumF [c]
+  | NegF c
+  | MulF { lhs : c, rhs : c}
+  | DivF { num : c, den : c}
+  -- | I (Expr t x a b , Expr t x a b)
+  | E_F { process : c, time : AcquisitionTime t x a, filtration : AcquisitionTime t x a }
+  deriving (Functor)
+
+instance Recursive (Expr t x a b) (ExprF t x a b) where
+  project (Const d) = ConstF d
+  project (Ident s) = IdentF s
+  project Proc{..} = ProcF with ..
+  -- project Sup{..} = SupF with ..
+  project (Sum xs) = SumF xs
+  project (Neg x) = NegF x
+  project (Mul (x,x')) = MulF x x'
+  project (Div (x, x')) = DivF x x'
+  -- project (I (x, x')) = I_F x x'
+  project E{..} = E_F with ..
+
+instance Corecursive (Expr t x a b) (ExprF t x a b) where
+  embed (ConstF d) = Const d
+  embed (IdentF s) = Ident s
+  embed ProcF{..} = Proc with ..
+  -- embed SupF{..} = Sup with ..
+  embed (SumF xs) = Sum xs
+  embed (NegF x) = Neg x
+  embed (MulF x x') = Mul (x, x')
+  embed (DivF x x') = Div (x, x')
+  -- embed (I_F x x') = I (x, x')
+  embed E_F{..} = E with ..
+
+instance Foldable (ExprF t x a b) where
+  foldMap f (ConstF _) = mempty
+  foldMap f (IdentF _) = mempty
+  foldMap f (ProcF _) = mempty
+  -- foldMap f (SupF _ _ x) = f x
+  foldMap f (SumF xs) = foldMap f xs
+  foldMap f (NegF x) = f x
+  foldMap f (MulF x x') = f x <> f x'
+  foldMap f (DivF x x') = f x <> f x'
+  -- foldMap f (I_F x x') = f x <> f x'
+  foldMap f (E_F x _ _) = f x
+
+instance Traversable (ExprF t x a b) where
+  sequence (ConstF d) = pure $ ConstF d
+  sequence (IdentF t) = pure $ IdentF t
+  sequence (ProcF x) = pure $ ProcF x
+--   sequence (SupF t τ fa) = SupF t τ <$> fa
+  sequence (SumF [fa]) = (\a -> SumF [a]) <$> fa
+  sequence (SumF (fa :: fas)) = s <$> fa <*> sequence fas
+    where s a as = SumF (a :: as)
+  sequence (SumF []) = error "Traversable ExprF: sequence empty SumF"
+  sequence (NegF fa) = NegF <$> fa
+  sequence (MulF fa fa') = MulF <$> fa <*> fa'
+  sequence (DivF fa fa') = DivF <$> fa <*> fa'
+--   sequence (I_F fa fa') = I_F <$> fa <*> fa'
+  sequence (E_F fa t f) = (\a -> E_F a t f) <$> fa
+
+instance (Additive x) => Additive (Expr t x a b) where
+  x + y = Sum [x, y]
+  negate = Neg
+  aunit = Const aunit
+
+instance (Multiplicative x) => Multiplicative (Expr t x a b) where
+  (*) = curry Mul
+  munit = Const munit
+  x ^ y | y > 0 = x * (x ^ pred y)
+  x ^ 0 = munit
+  x ^ y = curry Div munit $ x ^ (-y)
+
+-- [ML] we don't give as definition of Inv but use it to define power with negative integers
+
+instance (Multiplicative x) => Divisible (Expr t x a b) where
+  x / y = Div (x,y)
+
+-- [ML] we could define this as x * y ^ -1, but we are using the 
+-- fact that x * Div (munit,y) == Div (x,y)
+
+-- alternatively, instead of using Div Expr Expr we can just use Inv Expr (1 / Expr)

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -15,33 +15,34 @@ import Prelude hiding (Time, sequence, mapA, const)
 -- | Represents an algebraic expression of a t-adapted stochastic process
 -- t : time parameter
 -- x : state parameter, typically Decimal
--- a : reference used to identify observables
+-- o : reference used to identify observables
 -- b : type describing elementary processes
-data Expr t x a b
+data Expr t x o b
   = Const x
-    -- ^ a constant process
+      -- ^ A constant process.
   | Ident t
-    -- ^ a process that takes the value of the time parameter
+      -- ^ A process that takes the value of the time parameter.
   | Proc { name : b }
-    -- ^ an elementary process which we cannot decompose further
+      -- ^ An elementary process which we cannot decompose further.
   -- | Sup { lowerBound: t, tau: t, rv : Expr t }
-    -- ^ sup, needs to be reworked using feasible exercise strategies
-  | Sum [Expr t x a b]
-    -- ^ sum
-  | Neg (Expr t x a b)
-    -- ^ negation
-  | Mul (Expr t x a b, Expr t x a b)
-    -- ^ multiplication
-  | Div (Expr t x a b, Expr t x a b)
-    -- ^ division
-  -- | I (Expr t x a b , Expr t x a b)
-    -- ^ indicator function, rework using inequalities
-  | E { process : Expr t x a b, time : AcquisitionTime t x a, filtration : AcquisitionTime t x a }
-    -- ^ conditional expectation of `process(time)` conditioned on the filtration F_`t`
+      -- ^ Sup, needs to be reworked using feasible exercise strategies.
+  | Sum [Expr t x o b]
+      -- ^ Sum process.
+  | Neg (Expr t x o b)
+      -- ^ Negation process.
+  | Mul (Expr t x o b, Expr t x o b)
+      -- ^ Multiplication process.
+  | Div (Expr t x o b, Expr t x o b)
+      -- ^ Division process.
+      -- TODO think in which cases this is well defined
+  -- | I (Expr t x o b , Expr t x o b)
+      -- ^ Indicator function, rework using inequalities.
+  | E { process : Expr t x o b, time : AcquisitionTime t x o, filtration : AcquisitionTime t x o }
+      -- ^ Conditional expectation of `process(time)` conditioned on the filtration F_`t`.
   deriving (Eq,Show)
 
 -- | Base functor for `Expr`.
-data ExprF t x a b c
+data ExprF t x o b c
   = ConstF x
   | IdentF t
   | ProcF { name : b }
@@ -50,11 +51,11 @@ data ExprF t x a b c
   | NegF c
   | MulF { lhs : c, rhs : c}
   | DivF { num : c, den : c}
-  -- | I (Expr t x a b , Expr t x a b)
-  | E_F { process : c, time : AcquisitionTime t x a, filtration : AcquisitionTime t x a }
+  -- | I (Expr t x o b , Expr t x o b)
+  | E_F { process : c, time : AcquisitionTime t x o, filtration : AcquisitionTime t x o }
   deriving (Functor)
 
-instance Recursive (Expr t x a b) (ExprF t x a b) where
+instance Recursive (Expr t x o b) (ExprF t x o b) where
   project (Const d) = ConstF d
   project (Ident s) = IdentF s
   project Proc{..} = ProcF with ..
@@ -66,7 +67,7 @@ instance Recursive (Expr t x a b) (ExprF t x a b) where
   -- project (I (x, x')) = I_F x x'
   project E{..} = E_F with ..
 
-instance Corecursive (Expr t x a b) (ExprF t x a b) where
+instance Corecursive (Expr t x o b) (ExprF t x o b) where
   embed (ConstF d) = Const d
   embed (IdentF s) = Ident s
   embed ProcF{..} = Proc with ..
@@ -78,7 +79,7 @@ instance Corecursive (Expr t x a b) (ExprF t x a b) where
   -- embed (I_F x x') = I (x, x')
   embed E_F{..} = E with ..
 
-instance Foldable (ExprF t x a b) where
+instance Foldable (ExprF t x o b) where
   foldMap f (ConstF _) = mempty
   foldMap f (IdentF _) = mempty
   foldMap f (ProcF _) = mempty
@@ -90,7 +91,7 @@ instance Foldable (ExprF t x a b) where
   -- foldMap f (I_F x x') = f x <> f x'
   foldMap f (E_F x _ _) = f x
 
-instance Traversable (ExprF t x a b) where
+instance Traversable (ExprF t x o b) where
   sequence (ConstF d) = pure $ ConstF d
   sequence (IdentF t) = pure $ IdentF t
   sequence (ProcF x) = pure $ ProcF x
@@ -105,12 +106,12 @@ instance Traversable (ExprF t x a b) where
 --   sequence (I_F fa fa') = I_F <$> fa <*> fa'
   sequence (E_F fa t f) = (\a -> E_F a t f) <$> fa
 
-instance (Additive x) => Additive (Expr t x a b) where
+instance (Additive x) => Additive (Expr t x o b) where
   x + y = Sum [x, y]
   negate = Neg
   aunit = Const aunit
 
-instance (Multiplicative x) => Multiplicative (Expr t x a b) where
+instance (Multiplicative x) => Multiplicative (Expr t x o b) where
   (*) = curry Mul
   munit = Const munit
   x ^ y | y > 0 = x * (x ^ pred y)
@@ -119,10 +120,10 @@ instance (Multiplicative x) => Multiplicative (Expr t x a b) where
 
 -- [ML] we don't give as definition of Inv but use it to define power with negative integers
 
-instance (Multiplicative x) => Divisible (Expr t x a b) where
+instance (Multiplicative x) => Divisible (Expr t x o b) where
   x / y = Div (x,y)
 
--- [ML] we could define this as x * y ^ -1, but we are using the 
+-- [ML] we could define this as x * y ^ -1, but we are using the
 -- fact that x * Div (munit,y) == Div (x,y)
 
 -- alternatively, instead of using Div Expr Expr we can just use Inv Expr (1 / Expr)

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -6,6 +6,7 @@ module ContingentClaims.Math.Expression (
   ExprF(..),
 ) where
 
+import ContingentClaims.Claim (Inequality(..))
 import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..))
 import DA.Foldable
 import DA.Traversable
@@ -20,8 +21,6 @@ import Prelude hiding (Time, sequence, mapA, const)
 data Expr t x o b
   = Const x
       -- ^ A constant process.
-  | Ident t
-      -- ^ A process that takes the value of the time parameter.
   | Proc { name : b }
       -- ^ An elementary process which we cannot decompose further.
   -- | Sup { lowerBound: t, tau: t, rv : Expr t }
@@ -34,9 +33,13 @@ data Expr t x o b
       -- ^ Multiplication process.
   | Inv (Expr t x o b)
       -- ^ Inverse process.
-      -- TODO think in which cases this is well defined
-  -- | I (Expr t x o b , Expr t x o b)
-      -- ^ Indicator function, rework using inequalities.
+  | I (Inequality t x o)
+      -- ^ Indicator function. I(p) is 1 if p(t) = True, False otherwise, where
+      -- `p` is the boolen process corrersponding to the provided inequality.
+      -- Specifically, this means
+      -- - for `o1 ≤ o2`, `p = υ(o1) ≤ υ(o2)`
+      -- - for `TimeGte t`, `p(s) = s ≥ t`
+      -- - for `TimeLte t`, `p(s) = s ≤ t`
   | E { process : Expr t x o b, time : AcquisitionTime t x o, filtration : AcquisitionTime t x o }
       -- ^ Conditional expectation of `process(time)` conditioned on the filtration F_`t`.
   deriving (Eq,Show)
@@ -44,56 +47,51 @@ data Expr t x o b
 -- | Base functor for `Expr`.
 data ExprF t x o b c
   = ConstF x
-  | IdentF t
   | ProcF { name : b }
   -- | Sup { lowerBound: t, tau: t, rv : Expr t }
   | SumF [c]
   | NegF c
-  | MulF { lhs : c, rhs : c}
+  | MulF { lhs : c, rhs : c }
   | InvF c
-  -- | I (Expr t x o b , Expr t x o b)
+  | I_F (Inequality t x o)
   | E_F { process : c, time : AcquisitionTime t x o, filtration : AcquisitionTime t x o }
   deriving (Functor)
 
 instance Recursive (Expr t x o b) (ExprF t x o b) where
   project (Const d) = ConstF d
-  project (Ident s) = IdentF s
   project Proc{..} = ProcF with ..
   -- project Sup{..} = SupF with ..
   project (Sum xs) = SumF xs
   project (Neg x) = NegF x
   project (Mul (x,x')) = MulF x x'
   project (Inv x) = InvF x
-  -- project (I (x, x')) = I_F x x'
+  project (I x) = I_F x
   project E{..} = E_F with ..
 
 instance Corecursive (Expr t x o b) (ExprF t x o b) where
   embed (ConstF d) = Const d
-  embed (IdentF s) = Ident s
   embed ProcF{..} = Proc with ..
   -- embed SupF{..} = Sup with ..
   embed (SumF xs) = Sum xs
   embed (NegF x) = Neg x
   embed (MulF x x') = Mul (x, x')
   embed (InvF x) = Inv x
-  -- embed (I_F x x') = I (x, x')
+  embed (I_F x) = I x
   embed E_F{..} = E with ..
 
 instance Foldable (ExprF t x o b) where
   foldMap f (ConstF _) = mempty
-  foldMap f (IdentF _) = mempty
   foldMap f (ProcF _) = mempty
   -- foldMap f (SupF _ _ x) = f x
   foldMap f (SumF xs) = foldMap f xs
   foldMap f (NegF x) = f x
   foldMap f (MulF x x') = f x <> f x'
   foldMap f (InvF x) = f x
-  -- foldMap f (I_F x x') = f x <> f x'
+  foldMap f (I_F _) = mempty
   foldMap f (E_F x _ _) = f x
 
 instance Traversable (ExprF t x o b) where
   sequence (ConstF d) = pure $ ConstF d
-  sequence (IdentF t) = pure $ IdentF t
   sequence (ProcF x) = pure $ ProcF x
 --   sequence (SupF t τ fa) = SupF t τ <$> fa
   sequence (SumF [fa]) = (\a -> SumF [a]) <$> fa
@@ -103,7 +101,7 @@ instance Traversable (ExprF t x o b) where
   sequence (NegF fa) = NegF <$> fa
   sequence (MulF fa fa') = MulF <$> fa <*> fa'
   sequence (InvF fa) = InvF <$> fa
---   sequence (I_F fa fa') = I_F <$> fa <*> fa'
+  sequence (I_F p) = pure $ I_F p
   sequence (E_F fa t f) = (\a -> E_F a t f) <$> fa
 
 instance (Additive x) => Additive (Expr t x o b) where
@@ -120,8 +118,3 @@ instance (Multiplicative x) => Multiplicative (Expr t x o b) where
 
 instance (Multiplicative x) => Divisible (Expr t x o b) where
   x / y = curry Mul x $ Inv y
-
--- [ML] we could define this as x * y ^ -1, but we are using the
--- fact that x * Div (munit,y) == Div (x,y)
-
--- alternatively, instead of using Div Expr Expr we can just use Inv Expr (1 / Expr)

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -14,36 +14,43 @@ import Daml.Control.Recursion
 import Prelude hiding (Time, sequence, mapA, const)
 
 -- | Represents an algebraic expression of a t-adapted stochastic process.
--- t : time parameter
--- x : state parameter, typically Decimal (our best approximation of real numbers)
--- o : reference used to identify observables
--- b : type describing elementary processes
+-- t : time parameter.
+-- x : state parameter, typically Decimal (our best approximation of real numbers).
+-- o : reference used to identify observables.
+-- b : type describing elementary processes.
 data Expr t x o b
   = Const x
-      -- ^ A constant process.
+    -- ^ A constant process.
   | Proc { name : b }
-      -- ^ An elementary process which we cannot decompose further.
+    -- ^ An elementary process which we cannot decompose further.
   -- | Sup { lowerBound: t, tau: t, rv : Expr t }
-      -- ^ Sup, needs to be reworked using feasible exercise strategies.
+    -- -- ^ Sup, needs to be reworked using feasible exercise strategies.
   | Sum [Expr t x o b]
-      -- ^ Sum process.
+    -- ^ Sum process.
   | Neg (Expr t x o b)
-      -- ^ Negation process.
+    -- ^ Negation process.
   | Mul (Expr t x o b, Expr t x o b)
-      -- ^ Multiplication process.
+    -- ^ Multiplication process.
   | Inv (Expr t x o b)
-      -- ^ Inverse process.
+    -- ^ Inverse process.
   | Max [Expr t x o b]
-      -- ^ Maximum process.
+    -- ^ Maximum process.
   | I (Inequality t x o)
-      -- ^ Indicator function. I(p) is 1 if p(t) = True, False otherwise, where
-      -- `p` is the boolen process corrersponding to the provided inequality.
-      -- Specifically, this means
-      -- - for `o1 ≤ o2`, `p = υ(o1) ≤ υ(o2)`
-      -- - for `TimeGte t`, `p(s) = s ≥ t`
-      -- - for `TimeLte t`, `p(s) = s ≤ t`
+    -- ^ Indicator function. I(p) is 1 if p(t) = True, False otherwise, where
+    -- `p` is the boolen process corrersponding to the provided inequality.
+    -- Specifically, this means
+    -- - for `o1 ≤ o2`, `p = υ(o1) ≤ υ(o2)`
+    -- - for `TimeGte t`, `p(s) = s ≥ t`
+    -- - for `TimeLte t`, `p(s) = s ≤ t`
   | E { process : Expr t x o b, time : AcquisitionTime t x o, filtration : AcquisitionTime t x o }
-      -- ^ Conditional expectation of `process(time)` conditioned on the filtration F_`t`.
+    -- ^ Conditional expectation of `process(time)` conditioned on the filtration F_`t`.
+  -- | Snell { process : Expr t x o b, time : AcquisitionTime t x o, predicate : Inequality t x o}
+  --     -- ^ Snell envelope of a stochastic process.
+  --     -- We need the predicate to identify the feasible region
+  --     -- I feel that we need the acquisition time to identify the conditional filtration, but it might not be needed.
+  -- | Absorb { process : Expr t x o b, time : AcquisitionTime t x o, predicate : Inequality t x o}
+  --     -- ^ Absorb primitive.
+  --     -- It feels that absorb hides an expectation, but I need to write this down in formulas for better understanding.
   deriving (Eq,Show)
 
 -- | Base functor for `Expr`.

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -4,6 +4,7 @@
 module ContingentClaims.Math.Expression (
   Expr(..),
   ExprF(..),
+  simplify
 ) where
 
 import ContingentClaims.Claim (Inequality(..))
@@ -30,14 +31,14 @@ data Expr t x o b
   | Neg (Expr t x o b)
     -- ^ Negation process.
   | Mul (Expr t x o b, Expr t x o b)
-    -- ^ Multiplication process.
+    -- ^ Multiplication of two processes (`p1 * p2`).
   | Inv (Expr t x o b)
-    -- ^ Inverse process.
+    -- ^ Inverse of a process (`1 / p`).
   | Max [Expr t x o b]
     -- ^ Maximum process.
   | I (Inequality t x o)
     -- ^ Indicator function. I(p) is 1 if p(t) = True, False otherwise, where
-    -- `p` is the boolen process corrersponding to the provided inequality.
+    -- `p` is the boolen process corresponding to the provided inequality.
     -- Specifically, this means
     -- - for `o1 ≤ o2`, `p = υ(o1) ≤ υ(o2)`
     -- - for `TimeGte t`, `p(s) = s ≥ t`
@@ -51,6 +52,8 @@ data Expr t x o b
   -- | Absorb { process : Expr t x o b, time : AcquisitionTime t x o, predicate : Inequality t x o}
   --     -- ^ Absorb primitive.
   --     -- It feels that absorb hides an expectation, but I need to write this down in formulas for better understanding.
+  -- In order to write until valuation explicitly, we need to introduce a new class of boolean processes, namely those that we start observing at a time tau and have never been true since (we can then use an indicator function to transform it to a real process)
+  -- We can use the absorb primitive to cover this case, which we can then distribute. across the other primitives.
   deriving (Eq,Show)
 
 -- | Base functor for `Expr`.
@@ -134,3 +137,76 @@ instance (Multiplicative x) => Multiplicative (Expr t x o b) where
 
 instance (Multiplicative x) => Divisible (Expr t x o b) where
   x / y = curry Mul x $ Inv y
+
+-- | This is meant to be a function that algebraically simplifies the FAPF by
+-- 1) using simple identities and ring laws
+-- 2) change of numeraire technique.
+simplify : (Eq x, Eq b, Eq t, Eq o, Multiplicative x) => Expr t x o b -> Expr t x o b
+simplify =
+    cata unitIdentity
+  -- . cata zeroIdentity
+  . cata factNeg
+  -- . \case [] -> Const aunit
+  --         [x] -> x
+  --         xs -> Sum xs
+  -- . cata distSum
+  -- . ana commuteLeft
+  -- . cata mulBeforeSum
+
+-- {- Functions below here are helpers for simplifying the expression tree, used mainly in `simplify` -}
+
+-- | Algebra that simplifies sums, multiplications, expectations involving 0.0.
+-- BUG I need to add an additive typeclass constraint, otherwise aunit is just a pattern match.
+zeroIdentity : ExprF t x o b (Expr t x o b) -> Expr t x o b
+zeroIdentity (MulF (Const aunit) x) = Const aunit
+zeroIdentity (MulF x (Const aunit)) = Const aunit
+zeroIdentity (SumF xs) = Sum $ filter (not . isZero) xs
+  where isZero (Const aunit) = True
+        isZero _ = False
+zeroIdentity (E_F (Const aunit) _ _) = Const aunit
+zeroIdentity other = embed other
+
+-- | Algebra that simplifies multiplications and divisions by 1.0.
+unitIdentity : (Eq x, Eq b, Eq t, Eq o, Multiplicative x) => ExprF t x o b (Expr t x o b) -> Expr t x o b
+unitIdentity (MulF a b) | a == munit = b
+unitIdentity (MulF a b) | b == munit = a
+unitIdentity (InvF x) | x == munit = munit
+unitIdentity other = embed other
+
+-- | Algebra that collects and simplifies minuses.
+factNeg : ExprF t x o b (Expr t x o b) -> Expr t x o b
+factNeg (NegF (Neg x)) = x
+-- factNeg (MulF (Neg x) (Neg y)) = Mul (x, y) -- [ML] I think this is redundant
+factNeg (MulF (Neg x) y) = Neg $ Mul (x, y)
+factNeg (MulF y (Neg x)) = Neg $ Mul (y, x)
+factNeg (E_F (Neg x) t f) = Neg $ E x t f
+factNeg other = embed other
+
+-- -- | Turn any expression into a list of terms to be summed together
+-- distSum : ExprF t x o b [Expr t x o b] -> [Expr t x o b]
+-- distSum = \case
+--   ConstF x -> [Const x]
+--   SumF xs -> join xs
+--   MulF xs xs' -> curry Mul <$> xs <*> xs'
+--   NegF xs -> Neg <$> xs
+--   E_F xs t -> flip E t <$> xs
+--   I_F xs xs' -> [I (unroll xs, unroll xs')]
+--   ProcF{..} -> [Proc{..}]
+--   where unroll xs = Sum xs
+
+-- | Algebra that changes `(a + b) x c` to `c x (a + b)`
+-- mulBeforeSum : ExprF t x o b (Expr t x o b) -> Expr t x o b
+-- mulBeforeSum (MulF y@Sum{} x) = Mul (x, y)
+-- mulBeforeSum (MulF (Mul (x, y@Sum{})) x') = Mul (Mul (x,x'), y)
+-- mulBeforeSum other = embed other
+
+-- | Algebra that applies commutative property to all multiplications.
+-- commute : ExprF t x o b (Expr t x o b) -> Expr t x o b
+-- commute (MulF a b) = embed $ MulF b a
+-- commute other = embed other
+
+-- | Change e.g. `a x (b x c)` to `(a x b) x c`.
+-- We are not using commutative property, but rather associative --> should rename
+-- commuteLeft : Expr t x o b -> ExprF t x o b (Expr t x o b)
+-- commuteLeft (Mul (a,(Mul (b, c)))) = Mul (a, b) `MulF` c
+-- commuteLeft other = project other

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -32,8 +32,8 @@ data Expr t x o b
       -- ^ Negation process.
   | Mul (Expr t x o b, Expr t x o b)
       -- ^ Multiplication process.
-  | Div (Expr t x o b, Expr t x o b)
-      -- ^ Division process.
+  | Inv (Expr t x o b)
+      -- ^ Inverse process.
       -- TODO think in which cases this is well defined
   -- | I (Expr t x o b , Expr t x o b)
       -- ^ Indicator function, rework using inequalities.
@@ -50,7 +50,7 @@ data ExprF t x o b c
   | SumF [c]
   | NegF c
   | MulF { lhs : c, rhs : c}
-  | DivF { num : c, den : c}
+  | InvF c
   -- | I (Expr t x o b , Expr t x o b)
   | E_F { process : c, time : AcquisitionTime t x o, filtration : AcquisitionTime t x o }
   deriving (Functor)
@@ -63,7 +63,7 @@ instance Recursive (Expr t x o b) (ExprF t x o b) where
   project (Sum xs) = SumF xs
   project (Neg x) = NegF x
   project (Mul (x,x')) = MulF x x'
-  project (Div (x, x')) = DivF x x'
+  project (Inv x) = InvF x
   -- project (I (x, x')) = I_F x x'
   project E{..} = E_F with ..
 
@@ -75,7 +75,7 @@ instance Corecursive (Expr t x o b) (ExprF t x o b) where
   embed (SumF xs) = Sum xs
   embed (NegF x) = Neg x
   embed (MulF x x') = Mul (x, x')
-  embed (DivF x x') = Div (x, x')
+  embed (InvF x) = Inv x
   -- embed (I_F x x') = I (x, x')
   embed E_F{..} = E with ..
 
@@ -87,7 +87,7 @@ instance Foldable (ExprF t x o b) where
   foldMap f (SumF xs) = foldMap f xs
   foldMap f (NegF x) = f x
   foldMap f (MulF x x') = f x <> f x'
-  foldMap f (DivF x x') = f x <> f x'
+  foldMap f (InvF x) = f x
   -- foldMap f (I_F x x') = f x <> f x'
   foldMap f (E_F x _ _) = f x
 
@@ -102,7 +102,7 @@ instance Traversable (ExprF t x o b) where
   sequence (SumF []) = error "Traversable ExprF: sequence empty SumF"
   sequence (NegF fa) = NegF <$> fa
   sequence (MulF fa fa') = MulF <$> fa <*> fa'
-  sequence (DivF fa fa') = DivF <$> fa <*> fa'
+  sequence (InvF fa) = InvF <$> fa
 --   sequence (I_F fa fa') = I_F <$> fa <*> fa'
   sequence (E_F fa t f) = (\a -> E_F a t f) <$> fa
 
@@ -116,12 +116,10 @@ instance (Multiplicative x) => Multiplicative (Expr t x o b) where
   munit = Const munit
   x ^ y | y > 0 = x * (x ^ pred y)
   x ^ 0 = munit
-  x ^ y = curry Div munit $ x ^ (-y)
-
--- [ML] we don't give as definition of Inv but use it to define power with negative integers
+  x ^ y = Inv x ^ (-y)
 
 instance (Multiplicative x) => Divisible (Expr t x o b) where
-  x / y = Div (x,y)
+  x / y = curry Mul x $ Inv y
 
 -- [ML] we could define this as x * y ^ -1, but we are using the
 -- fact that x * Div (munit,y) == Div (x,y)

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -15,7 +15,7 @@ import Prelude hiding (Time, sequence, mapA, const)
 
 -- | Represents an algebraic expression of a t-adapted stochastic process.
 -- t : time parameter
--- x : state parameter, typically Decimal
+-- x : state parameter, typically Decimal (our best approximation of real numbers)
 -- o : reference used to identify observables
 -- b : type describing elementary processes
 data Expr t x o b
@@ -33,6 +33,8 @@ data Expr t x o b
       -- ^ Multiplication process.
   | Inv (Expr t x o b)
       -- ^ Inverse process.
+  | Max [Expr t x o b]
+      -- ^ Maximum process.
   | I (Inequality t x o)
       -- ^ Indicator function. I(p) is 1 if p(t) = True, False otherwise, where
       -- `p` is the boolen process corrersponding to the provided inequality.
@@ -53,6 +55,7 @@ data ExprF t x o b c
   | NegF c
   | MulF { lhs : c, rhs : c }
   | InvF c
+  | MaxF [c]
   | I_F (Inequality t x o)
   | E_F { process : c, time : AcquisitionTime t x o, filtration : AcquisitionTime t x o }
   deriving (Functor)
@@ -65,6 +68,7 @@ instance Recursive (Expr t x o b) (ExprF t x o b) where
   project (Neg x) = NegF x
   project (Mul (x,x')) = MulF x x'
   project (Inv x) = InvF x
+  project (Max xs) = MaxF xs
   project (I x) = I_F x
   project E{..} = E_F with ..
 
@@ -76,6 +80,7 @@ instance Corecursive (Expr t x o b) (ExprF t x o b) where
   embed (NegF x) = Neg x
   embed (MulF x x') = Mul (x, x')
   embed (InvF x) = Inv x
+  embed (MaxF xs) = Max xs
   embed (I_F x) = I x
   embed E_F{..} = E with ..
 
@@ -87,6 +92,7 @@ instance Foldable (ExprF t x o b) where
   foldMap f (NegF x) = f x
   foldMap f (MulF x x') = f x <> f x'
   foldMap f (InvF x) = f x
+  foldMap f (MaxF xs) = foldMap f xs
   foldMap f (I_F _) = mempty
   foldMap f (E_F x _ _) = f x
 
@@ -101,6 +107,9 @@ instance Traversable (ExprF t x o b) where
   sequence (NegF fa) = NegF <$> fa
   sequence (MulF fa fa') = MulF <$> fa <*> fa'
   sequence (InvF fa) = InvF <$> fa
+  sequence (MaxF (fa :: fas)) = s <$> fa <*> sequence fas
+    where s a as = MaxF (a :: as)
+  sequence (MaxF []) = error "Traversable ExprF: sequence empty MaxF"
   sequence (I_F p) = pure $ I_F p
   sequence (E_F fa t f) = (\a -> E_F a t f) <$> fa
 

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -38,7 +38,7 @@ data Expr t x o b
     -- ^ Maximum process.
   | I (Inequality t x o)
     -- ^ Indicator function. I(p) is 1 if p(t) = True, False otherwise, where
-    -- `p` is the boolen process corresponding to the provided inequality.
+    -- `p` is the boolean process corresponding to the provided inequality.
     -- Specifically, this means
     -- - for `o1 ≤ o2`, `p = υ(o1) ≤ υ(o2)`
     -- - for `TimeGte t`, `p(s) = s ≥ t`

--- a/daml/ContingentClaims/Math/Expression.daml
+++ b/daml/ContingentClaims/Math/Expression.daml
@@ -12,7 +12,7 @@ import DA.Traversable
 import Daml.Control.Recursion
 import Prelude hiding (Time, sequence, mapA, const)
 
--- | Represents an algebraic expression of a t-adapted stochastic process
+-- | Represents an algebraic expression of a t-adapted stochastic process.
 -- t : time parameter
 -- x : state parameter, typically Decimal
 -- o : reference used to identify observables

--- a/daml/ContingentClaims/Math/Stochastic.daml
+++ b/daml/ContingentClaims/Math/Stochastic.daml
@@ -11,8 +11,6 @@ module ContingentClaims.Math.Stochastic (
   , IsIdentifier(..)
   , Process(..)
   , riskless
-  , simplify
-  , unitIdentity
 ) where
 
 import ContingentClaims.Internal.Claim(Claim(..), Inequality(..))
@@ -191,71 +189,3 @@ fapf ccy disc exch val today = flip evalState 0 . futuM coalg . Left . (, today)
   val' obs t = ProcF (show obs) (val obs) t
   one = munit
   zero = aunit
-
-{-# WARNING simplify "This is an experimental feature" #-}
--- | This is meant to be a function that algebraically simplifies the FAPF by
--- 1) using simple identities and ring laws
--- 2) change of numeraire technique.
-simplify : Expr t -> Expr t
-simplify =
-    cata unitIdentity
-  . cata zeroIdentity
-  . cata factNeg
-  . \case [] -> Const aunit
-          [x] -> x
-          xs -> Sum xs
-  . cata distSum
-  . ana commuteLeft
-  . cata mulBeforeSum
-
-{- Functions below here are helpers for simplifying the expression tree, used mainly in `simplify` -}
-
-zeroIdentity : ExprF t (Expr t) -> Expr t
-zeroIdentity (MulF (Const 0.0) x) = Const 0.0
-zeroIdentity (MulF x (Const 0.0)) = Const 0.0
-zeroIdentity (PowF x (Const 0.0)) = Const 1.0
-zeroIdentity (SumF xs) = Sum $ filter (not . isZero) xs
-  where isZero (Const 0.0) = True
-        isZero _ = False
-zeroIdentity (E_F (Const 0.0) _) = Const 0.0
-zeroIdentity other = embed other
-
-unitIdentity : ExprF t (Expr t) -> Expr t
-unitIdentity (MulF (Const 1.0) x) = x
-unitIdentity (MulF x (Const 1.0)) = x
-unitIdentity (PowF x (Const 1.0)) = x
-unitIdentity other = embed other
-
-factNeg : ExprF t (Expr t) -> Expr t
-factNeg (NegF (Neg x)) = x
-factNeg (MulF (Neg x) (Neg y)) = Mul (x, y)
-factNeg (MulF (Neg x) y) = Neg $ Mul (x, y)
-factNeg (MulF y (Neg x)) = Neg $ Mul (y, x)
-factNeg (E_F (Neg x) t) = Neg $ E x t
-factNeg other = embed other
-
--- | Turn any expression into a list of terms to be summed together
-distSum : ExprF t [Expr t] -> [Expr t]
-distSum = \case
-  ConstF x -> [Const x]
-  IdentF x -> [Ident x]
-  SumF xs -> join xs
-  MulF xs xs' -> curry Mul <$> xs <*> xs'
-  NegF xs -> Neg <$> xs
-  E_F xs t -> flip E t <$> xs
-  I_F xs xs' -> [I (unroll xs, unroll xs')]
-  PowF xs is -> [Pow (unroll xs, unroll is)]
-  ProcF{..} -> [Proc{..}]
-  SupF t τ xs -> [Sup t τ (unroll xs)]
-  where unroll xs = Sum xs
-
--- | Change `(a + b) x c` to `c x (a + b)`
-mulBeforeSum : ExprF t (Expr t) -> Expr t
-mulBeforeSum (MulF y@Sum{} x) = Mul (x, y)
-mulBeforeSum (MulF (Mul (x, y@Sum{})) x') = Mul (Mul (x,x'), y)
-mulBeforeSum other = embed other
-
--- | Change e.g. `a x (b x c)` to `(a x b) x c`
-commuteLeft : Expr t -> ExprF t (Expr t)
-commuteLeft (Mul (x,(Mul (a, b)))) = Mul (x, a) `MulF` b
-commuteLeft other = project other

--- a/daml/ContingentClaims/Math/Stochastic2.daml
+++ b/daml/ContingentClaims/Math/Stochastic2.daml
@@ -79,6 +79,9 @@ fapf spot ccy t acquisitionTime claim =
 ϵ _ _ _ (And c c' cs, s) = pure . SumF $ fmap (claim . (, s)) (c :: c' :: cs)
   where claim = pure . Left
 
+ϵ _ _ _ (Or c c' cs, s) = pure . MaxF $ fmap (claim . (, s)) (c :: c' :: cs)
+  where claim = pure . Left
+
 ϵ spot t ccy (When pred c, s) | beforeOrAtToday t τ == Some True = ϵ spot t ccy (c, τ)
   where τ = extend pred s
 -- ^ the acquisition time of the inner contract is known and not in the future

--- a/daml/ContingentClaims/Math/Stochastic2.daml
+++ b/daml/ContingentClaims/Math/Stochastic2.daml
@@ -8,7 +8,7 @@ module ContingentClaims.Math.Stochastic2 (
 
 import ContingentClaims.Internal.Claim (Claim(..))
 import ContingentClaims.Claim hiding ((<=))
-import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..), beforeOrAtToday, extend, resolve)
+import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..), beforeOrAtToday, extend, isNever)
 import ContingentClaims.Math.Expression
 import ContingentClaims.Observation qualified as O
 import ContingentClaims.Util.Recursion (futuM)
@@ -90,6 +90,9 @@ fapf spot ccy t acquisitionTime claim =
 -- When, the acquisition time of the inner contract is known and not in the future
 ϵ spot t ccy (When pred c, s) | beforeOrAtToday t τ == Some True = ϵ spot t ccy (c, τ)
   where τ = extend pred s
+-- When, the acquisition time of the inner contract never happens
+ϵ spot t ccy (When pred c, s) | isNever τ = pure $ ConstF aunit
+  where τ = extend pred s
 -- When, the acquisition time of the inner contract is either unknown or known but in the future
 ϵ _ t ccy (When pred c, s) = pure $ MulF (ex (disc * claim (c,τ)) τ filtration) $ inv disc
   where τ = extend pred s
@@ -102,11 +105,9 @@ fapf spot ccy t acquisitionTime claim =
         ex e τ f = Free $ E_F e τ f
         inv = Free . InvF
 -- Cond, the acquisition time of the inner contract is known and not in the future
-ϵ spot t ccy (Cond pred c1 c2, s) | beforeOrAtToday t s == Some True = do
-  let
-    Some obsTime = resolve s
-  predicate <- compare spot pred obsTime
-  if predicate then ϵ spot t ccy (c1, s) else ϵ spot t ccy (c2, s)
+ϵ spot t ccy (Cond pred c1 c2, Time s) | s <= t = do
+  predicate <- compare spot pred s
+  if predicate then ϵ spot t ccy (c1, Time s) else ϵ spot t ccy (c2, Time s)
 -- Cond, the acquisition time is either unknown or known but in the future
 ϵ spot t ccy (Cond pred c1 c2, s) =
   let

--- a/daml/ContingentClaims/Math/Stochastic2.daml
+++ b/daml/ContingentClaims/Math/Stochastic2.daml
@@ -85,7 +85,7 @@ fapf spot ccy t acquisitionTime claim =
   where τ = extend pred s
 -- ^ the acquisition time of the inner contract is known and not in the future
 
-ϵ t ccy (When pred c, s) = pure $ DivF (ex ( disc * claim (c,τ) ) τ filtration) disc
+ϵ t ccy (When pred c, s) = pure $ MulF (ex (disc * claim (c,τ)) τ filtration) $ inv disc
   where τ = extend pred s
         filtration = case s of
           AtInequality _ -> s -- acquisition time of the outer contract is unknown
@@ -94,6 +94,7 @@ fapf spot ccy t acquisitionTime claim =
         disc = Free . ProcF $ Disc ccy
         x * y = Free $ MulF x y
         ex e τ f = Free $ E_F e τ f
+        inv = Free . InvF
 -- ^ the acquisition time of the inner contract is either unknown or known but in the future
 
 -- DONE:

--- a/daml/ContingentClaims/Math/Stochastic2.daml
+++ b/daml/ContingentClaims/Math/Stochastic2.daml
@@ -9,44 +9,43 @@ module ContingentClaims.Math.Stochastic2 (
   ElementaryProcess(..),
 ) where
 
+import ContingentClaims.Internal.Claim (Claim(..))
 import ContingentClaims.Claim hiding (compare,(<=))
 import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..), beforeOrAtToday, extend)
 import ContingentClaims.Math.Expression
 import ContingentClaims.Observation qualified as O
-import ContingentClaims.Util (intrinsicAcquisitionTime)
 import ContingentClaims.Util.Recursion (futuM)
-import DA.Optional (fromSomeNote)
 import Daml.Control.Arrow ((|||))
 import Daml.Control.Recursion
 
 -- | Elementary processes as described in the Peyton-Jones paper.
 -- Once a model assumption is made, these can be replaced by the specific model (e.g. geometric brownian motion for stock spot prices)
-data ElementaryProcess a
-  = Observable a
-    -- ^ process corresponding to observable a
+data ElementaryProcess a o
+  = Observable o
+      -- ^ Process corresponding to an observable.
   | Exch with { asset : a, currency : a }
-    -- ^ value of `asset` expressed in units of `currency`
+      -- ^ Value of `asset` expressed in units of `currency`.
   | Disc a
-    -- ^ discount factor expressed in currency `a`
+      -- ^ Discount factor expressed in currency `a`.
   deriving (Eq, Show)
 
 -- | Maps a claim to the corresponding value process in currency `ccy`, taking into account known information up to time `t`.
 fapf : (Ord t, Eq a, Additive x, Multiplicative x, CanAbort m)
-  => (a -> t -> m x)
+  => (o -> t -> m x)
      -- ^ function to evaluate observables
   -> a
      -- ^ currency
   -> t
      -- ^ valuation date
-  -> Claim t x a
+  -> t
+     -- ^ acquisition time
+  -> Claim t x a o
      -- ^ the input claim
-  -> m (Expr t x a (ElementaryProcess a))
-fapf spot ccy t claim =
+  -> m (Expr t x o (ElementaryProcess a o))
+fapf spot ccy t acquisitionTime claim =
   futuM coalg
-  $ Left (claim, acquisitionTime) -- `Left` is used for claims, `Right` for observables
+  $ Left (claim, Time acquisitionTime) -- `Left` is used for claims, `Right` for observables
   where
-    acquisitionTime = Time . fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
-
     -- coalg : (Additive x) => (Carrier t x a) -> (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
     coalg = ϵ t ccy ||| υ
 
@@ -65,7 +64,7 @@ fapf spot ccy t claim =
 
   -- check when we should evaluate an observable
 
-ϵ : (Eq a, Ord t, Additive x, Multiplicative x, CanAbort m) => t -> a -> (Claim t x a, AcquisitionTime t x a) -> m (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
+ϵ : (Eq a, Ord t, Additive x, Multiplicative x, CanAbort m) => t -> a -> (Claim t x a o, AcquisitionTime t x o) -> m (ExprF t x o (ElementaryProcess a o) (Free (ExprF t x o (ElementaryProcess a o)) (Carrier t x a o)))
 
 ϵ _ _ (Zero, _) = pure $ ConstF aunit
 
@@ -86,7 +85,7 @@ fapf spot ccy t claim =
   where τ = extend pred s
 -- ^ the acquisition time of the inner contract is known and not in the future
 
-ϵ t ccy (When pred c, s) = pure $ DivF (ex ( disc * claim (c,τ) ) τ filtration) disc 
+ϵ t ccy (When pred c, s) = pure $ DivF (ex ( disc * claim (c,τ) ) τ filtration) disc
   where τ = extend pred s
         filtration = case s of
           AtInequality _ -> s -- acquisition time of the outer contract is unknown
@@ -97,7 +96,7 @@ fapf spot ccy t claim =
         ex e τ f = Free $ E_F e τ f
 -- ^ the acquisition time of the inner contract is either unknown or known but in the future
 
--- DONE: 
+-- DONE:
 -- zero
 -- one
 -- give
@@ -114,7 +113,7 @@ fapf spot ccy t claim =
 
 -- | HIDE
 -- Carrier of the CV-coalgebra ϵ ||| υ
-type Carrier t x a = Either (Claim t x a, AcquisitionTime t x a) (O.Observation t x a, AcquisitionTime t x a)
+type Carrier t x a o = Either (Claim t x a o, AcquisitionTime t x o) (O.Observation t x o, AcquisitionTime t x o)
 
 
 

--- a/daml/ContingentClaims/Math/Stochastic2.daml
+++ b/daml/ContingentClaims/Math/Stochastic2.daml
@@ -10,13 +10,14 @@ module ContingentClaims.Math.Stochastic2 (
 ) where
 
 import ContingentClaims.Internal.Claim (Claim(..))
-import ContingentClaims.Claim hiding (compare,(<=))
-import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..), beforeOrAtToday, extend)
+import ContingentClaims.Claim hiding ((<=))
+import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..), beforeOrAtToday, extend, resolve)
 import ContingentClaims.Math.Expression
 import ContingentClaims.Observation qualified as O
 import ContingentClaims.Util.Recursion (futuM)
 import Daml.Control.Arrow ((|||))
 import Daml.Control.Recursion
+import Prelude hiding (compare)
 
 -- | Elementary processes as described in the Peyton-Jones paper.
 -- Once a model assumption is made, these can be replaced by the specific model (e.g. geometric brownian motion for stock spot prices)
@@ -30,7 +31,7 @@ data ElementaryProcess a o
   deriving (Eq, Show)
 
 -- | Maps a claim to the corresponding value process in currency `ccy`, taking into account known information up to time `t`.
-fapf : (Ord t, Eq a, Additive x, Multiplicative x, CanAbort m)
+fapf : (Ord t, Eq a, Ord x, Number x, Divisible x, CanAbort m)
   => (o -> t -> m x)
      -- ^ function to evaluate observables
   -> a
@@ -47,7 +48,7 @@ fapf spot ccy t acquisitionTime claim =
   $ Left (claim, Time acquisitionTime) -- `Left` is used for claims, `Right` for observables
   where
     -- coalg : (Additive x) => (Carrier t x a) -> (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
-    coalg = ϵ t ccy ||| υ
+    coalg = ϵ spot t ccy ||| υ
 
     -- υ : (O.Observation t x a, AcquisitionTime t x a) -> (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
     υ (O.Const {value=k}, _) = pure $ ConstF k
@@ -56,36 +57,33 @@ fapf spot ccy t acquisitionTime claim =
     υ (O.Add (x, x'), s) = pure $ SumF [obs (x, s), obs (x', s)]
     υ (O.Neg x, s) =  pure . NegF $ obs (x, s)
     υ (O.Mul (x, x'), s) = pure $ obs (x, s) `MulF` obs (x', s)
-    -- υ (O.Div (x, x'), t) = obs (x, t) `MulF` inv (obs (x', t))
-    -- ^ check if we prefer using Divisible instead of power
-    υ other = abort ""
+    υ (O.Div (x, x'), t) = pure $ obs (x, t) `MulF` inv (obs (x', t))
 
     obs = pure . Right
+    inv = Free . InvF
 
-  -- check when we should evaluate an observable
+ϵ : (Eq a, Ord t, Ord x, Number x, Divisible x, CanAbort m) => (o -> t -> m x) -> t -> a -> (Claim t x a o, AcquisitionTime t x o) -> m (ExprF t x o (ElementaryProcess a o) (Free (ExprF t x o (ElementaryProcess a o)) (Carrier t x a o)))
 
-ϵ : (Eq a, Ord t, Additive x, Multiplicative x, CanAbort m) => t -> a -> (Claim t x a o, AcquisitionTime t x o) -> m (ExprF t x o (ElementaryProcess a o) (Free (ExprF t x o (ElementaryProcess a o)) (Carrier t x a o)))
+ϵ _ _ _ (Zero, _) = pure $ ConstF aunit
 
-ϵ _ _ (Zero, _) = pure $ ConstF aunit
-
-ϵ _ ccy (One asset, _) = pure $ exch asset ccy
+ϵ _ _ ccy (One asset, _) = pure $ exch asset ccy
   where
     exch asset ccy = if asset == ccy then ConstF munit else ProcF $ Exch asset ccy
 
-ϵ _ _ (Give c, s) = pure . NegF $ Pure $ Left (c,s)
+ϵ _ _ _ (Give c, s) = pure . NegF $ Pure $ Left (c,s)
 
-ϵ _ _ (Scale k c, s) = pure $ obs (k,s) `MulF` claim (c,s)
+ϵ _ _ _ (Scale k c, s) = pure $ obs (k,s) `MulF` claim (c,s)
   where obs = pure . Right
         claim = pure . Left
 
-ϵ _ _ (And c c' cs, s) = pure . SumF $ fmap (claim . (, s)) (c :: c' :: cs)
+ϵ _ _ _ (And c c' cs, s) = pure . SumF $ fmap (claim . (, s)) (c :: c' :: cs)
   where claim = pure . Left
 
-ϵ t ccy (When pred c, s) | beforeOrAtToday t τ == Some True = ϵ t ccy (c, τ)
+ϵ spot t ccy (When pred c, s) | beforeOrAtToday t τ == Some True = ϵ spot t ccy (c, τ)
   where τ = extend pred s
 -- ^ the acquisition time of the inner contract is known and not in the future
 
-ϵ t ccy (When pred c, s) = pure $ MulF (ex (disc * claim (c,τ)) τ filtration) $ inv disc
+ϵ _ t ccy (When pred c, s) = pure $ MulF (ex (disc * claim (c,τ)) τ filtration) $ inv disc
   where τ = extend pred s
         filtration = case s of
           AtInequality _ -> s -- acquisition time of the outer contract is unknown
@@ -97,6 +95,28 @@ fapf spot ccy t acquisitionTime claim =
         inv = Free . InvF
 -- ^ the acquisition time of the inner contract is either unknown or known but in the future
 
+ϵ spot t ccy (Cond pred c1 c2, s) | beforeOrAtToday t s == Some True = do
+  let
+    Some obsTime = resolve s
+  predicate <- compare spot pred obsTime
+  if predicate then ϵ spot t ccy (c1, s) else ϵ spot t ccy (c2, s)
+-- ^ the acquisition time of the `Cond` node is known and not in the future
+-- potentially we could replace this by a 1 * if we want to avoid the recursive call inside the RV-coalgebra
+
+ϵ spot t ccy (Cond pred c1 c2, s) =
+  let
+    v1 = ind pred * claim (c1,s)
+    v2 = (one - ind pred) * claim (c2,s)
+  in
+    pure $ SumF [v1, v2]
+  where claim = pure . Left
+        x - y = Free $ SumF [x, (Free $ NegF y)]
+        x * y = Free $ MulF x y
+        ind = Free . I_F
+        one = Free $ ConstF munit
+-- ^ the acquisition time of the inner contract is either unknown or known but in the future
+-- Value is ind(p) * c1 + (1 - ind(p)) * c2 where p is the boolean process implied by the inequality
+
 -- DONE:
 -- zero
 -- one
@@ -104,13 +124,15 @@ fapf spot ccy t acquisitionTime claim =
 -- scale
 -- when
 -- and
+-- cond
 
 -- MISSING :
 -- or
 -- anytime
 -- until
--- cond
-ϵ _ _ _ = abort "Unsupported primitive"
+ϵ _ _ _ _ = abort "Unsupported primitive"
+
+-- TODO how do we calculate value given initial acquisition time? We need to discount as of today so probably need to introduce an extra discount term disc s / disc t initially ...
 
 -- | HIDE
 -- Carrier of the CV-coalgebra ϵ ||| υ

--- a/daml/ContingentClaims/Math/Stochastic2.daml
+++ b/daml/ContingentClaims/Math/Stochastic2.daml
@@ -1,0 +1,122 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Mathematical expression, derived from `Claim`, used for pricing
+
+-- | Can I add some module description?
+module ContingentClaims.Math.Stochastic2 (
+  fapf,
+  ElementaryProcess(..),
+) where
+
+import ContingentClaims.Claim hiding (compare,(<=))
+import ContingentClaims.Math.AcquisitionTime(AcquisitionTime(..), beforeOrAtToday, extend)
+import ContingentClaims.Math.Expression
+import ContingentClaims.Observation qualified as O
+import ContingentClaims.Util (intrinsicAcquisitionTime)
+import ContingentClaims.Util.Recursion (futuM)
+import DA.Optional (fromSomeNote)
+import Daml.Control.Arrow ((|||))
+import Daml.Control.Recursion
+
+-- | Elementary processes as described in the Peyton-Jones paper.
+-- Once a model assumption is made, these can be replaced by the specific model (e.g. geometric brownian motion for stock spot prices)
+data ElementaryProcess a
+  = Observable a
+    -- ^ process corresponding to observable a
+  | Exch with { asset : a, currency : a }
+    -- ^ value of `asset` expressed in units of `currency`
+  | Disc a
+    -- ^ discount factor expressed in currency `a`
+  deriving (Eq, Show)
+
+-- | Maps a claim to the corresponding value process in currency `ccy`, taking into account known information up to time `t`.
+fapf : (Ord t, Eq a, Additive x, Multiplicative x, CanAbort m)
+  => (a -> t -> m x)
+     -- ^ function to evaluate observables
+  -> a
+     -- ^ currency
+  -> t
+     -- ^ valuation date
+  -> Claim t x a
+     -- ^ the input claim
+  -> m (Expr t x a (ElementaryProcess a))
+fapf spot ccy t claim =
+  futuM coalg
+  $ Left (claim, acquisitionTime) -- `Left` is used for claims, `Right` for observables
+  where
+    acquisitionTime = Time . fromSomeNote "Claim does not have an intrinsic acquisition time" $ intrinsicAcquisitionTime claim
+
+    -- coalg : (Additive x) => (Carrier t x a) -> (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
+    coalg = ϵ t ccy ||| υ
+
+    -- υ : (O.Observation t x a, AcquisitionTime t x a) -> (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
+    υ (O.Const {value=k}, _) = pure $ ConstF k
+    υ (O.Observe {key=observable}, Time s) | s <= t = ConstF <$> spot observable s
+    υ (O.Observe {key=observable}, s) = pure . ProcF $ Observable observable
+    υ (O.Add (x, x'), s) = pure $ SumF [obs (x, s), obs (x', s)]
+    υ (O.Neg x, s) =  pure . NegF $ obs (x, s)
+    υ (O.Mul (x, x'), s) = pure $ obs (x, s) `MulF` obs (x', s)
+    -- υ (O.Div (x, x'), t) = obs (x, t) `MulF` inv (obs (x', t))
+    -- ^ check if we prefer using Divisible instead of power
+    υ other = abort ""
+
+    obs = pure . Right
+
+  -- check when we should evaluate an observable
+
+ϵ : (Eq a, Ord t, Additive x, Multiplicative x, CanAbort m) => t -> a -> (Claim t x a, AcquisitionTime t x a) -> m (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
+
+ϵ _ _ (Zero, _) = pure $ ConstF aunit
+
+ϵ _ ccy (One asset, _) = pure $ exch asset ccy
+  where
+    exch asset ccy = if asset == ccy then ConstF munit else ProcF $ Exch asset ccy
+
+ϵ _ _ (Give c, s) = pure . NegF $ Pure $ Left (c,s)
+
+ϵ _ _ (Scale k c, s) = pure $ obs (k,s) `MulF` claim (c,s)
+  where obs = pure . Right
+        claim = pure . Left
+
+ϵ _ _ (And c c' cs, s) = pure . SumF $ fmap (claim . (, s)) (c :: c' :: cs)
+  where claim = pure . Left
+
+ϵ t ccy (When pred c, s) | beforeOrAtToday t τ == Some True = ϵ t ccy (c, τ)
+  where τ = extend pred s
+-- ^ the acquisition time of the inner contract is known and not in the future
+
+ϵ t ccy (When pred c, s) = pure $ DivF (ex ( disc * claim (c,τ) ) τ filtration) disc 
+  where τ = extend pred s
+        filtration = case s of
+          AtInequality _ -> s -- acquisition time of the outer contract is unknown
+          other -> extend (TimeGte t) s -- acquisition time of the outer contract is known
+        claim = pure . Left
+        disc = Free . ProcF $ Disc ccy
+        x * y = Free $ MulF x y
+        ex e τ f = Free $ E_F e τ f
+-- ^ the acquisition time of the inner contract is either unknown or known but in the future
+
+-- DONE: 
+-- zero
+-- one
+-- give
+-- scale
+-- when
+-- and
+
+-- MISSING :
+-- or
+-- anytime
+-- until
+-- cond
+ϵ _ _ _ = abort "Unsupported primitive"
+
+-- | HIDE
+-- Carrier of the CV-coalgebra ϵ ||| υ
+type Carrier t x a = Either (Claim t x a, AcquisitionTime t x a) (O.Observation t x a, AcquisitionTime t x a)
+
+
+
+
+

--- a/daml/ContingentClaims/Math/Stochastic2.daml
+++ b/daml/ContingentClaims/Math/Stochastic2.daml
@@ -1,12 +1,9 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- Mathematical expression, derived from `Claim`, used for pricing
-
--- | Can I add some module description?
 module ContingentClaims.Math.Stochastic2 (
-  fapf,
   ElementaryProcess(..),
+  fapf,
 ) where
 
 import ContingentClaims.Internal.Claim (Claim(..))
@@ -20,7 +17,7 @@ import Daml.Control.Recursion
 import Prelude hiding (compare)
 
 -- | Elementary processes as described in the Peyton-Jones paper.
--- Once a model assumption is made, these can be replaced by the specific model (e.g. geometric brownian motion for stock spot prices)
+-- Once a model assumption is made, these can be replaced by the specific model (e.g. geometric brownian motion for stock spot prices).
 data ElementaryProcess a o
   = Observable o
       -- ^ Process corresponding to an observable.
@@ -33,15 +30,15 @@ data ElementaryProcess a o
 -- | Maps a claim to the corresponding value process in currency `ccy`, taking into account known information up to time `t`.
 fapf : (Ord t, Eq a, Ord x, Number x, Divisible x, CanAbort m)
   => (o -> t -> m x)
-     -- ^ function to evaluate observables
+    -- ^ Function to evaluate observables.
   -> a
-     -- ^ currency
+    -- ^ Currency.
   -> t
-     -- ^ valuation date
+    -- ^ Valuation date.
   -> t
-     -- ^ acquisition time
+    -- ^ The claim's (known) acquisition time.
   -> Claim t x a o
-     -- ^ the input claim
+    -- ^ The input claim.
   -> m (Expr t x o (ElementaryProcess a o))
 fapf spot ccy t acquisitionTime claim =
   futuM coalg
@@ -49,7 +46,6 @@ fapf spot ccy t acquisitionTime claim =
   where
     -- coalg : (Additive x) => (Carrier t x a) -> (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
     coalg = ϵ spot t ccy ||| υ
-
     -- υ : (O.Observation t x a, AcquisitionTime t x a) -> (ExprF t x a (ElementaryProcess a) (Free (ExprF t x a (ElementaryProcess a)) (Carrier t x a)))
     υ (O.Const {value=k}, _) = pure $ ConstF k
     υ (O.Observe {key=observable}, Time s) | s <= t = ConstF <$> spot observable s
@@ -58,34 +54,43 @@ fapf spot ccy t acquisitionTime claim =
     υ (O.Neg x, s) =  pure . NegF $ obs (x, s)
     υ (O.Mul (x, x'), s) = pure $ obs (x, s) `MulF` obs (x', s)
     υ (O.Div (x, x'), t) = pure $ obs (x, t) `MulF` inv (obs (x', t))
-
     obs = pure . Right
     inv = Free . InvF
 
-ϵ : (Eq a, Ord t, Ord x, Number x, Divisible x, CanAbort m) => (o -> t -> m x) -> t -> a -> (Claim t x a o, AcquisitionTime t x o) -> m (ExprF t x o (ElementaryProcess a o) (Free (ExprF t x o (ElementaryProcess a o)) (Carrier t x a o)))
-
+-- | HIDE
+-- Valuation semantics for a `Claim`.
+ϵ : (Eq a, Ord t, Ord x, Number x, Divisible x, CanAbort m)
+  => (o -> t -> m x)
+    -- ^ Function to evaluate observables.
+  -> t
+    -- ^ Valuation date.
+  -> a
+    -- ^ Currency.
+  -> (Claim t x a o, AcquisitionTime t x o)
+    -- ^ The input claim and its acquisition time.
+  -> m (ExprF t x o (ElementaryProcess a o) (Free (ExprF t x o (ElementaryProcess a o)) (Carrier t x a o)))
+-- Zero
 ϵ _ _ _ (Zero, _) = pure $ ConstF aunit
-
+-- One
 ϵ _ _ ccy (One asset, _) = pure $ exch asset ccy
   where
     exch asset ccy = if asset == ccy then ConstF munit else ProcF $ Exch asset ccy
-
+-- Give
 ϵ _ _ _ (Give c, s) = pure . NegF $ Pure $ Left (c,s)
-
+-- Scale
 ϵ _ _ _ (Scale k c, s) = pure $ obs (k,s) `MulF` claim (c,s)
   where obs = pure . Right
         claim = pure . Left
-
+-- And
 ϵ _ _ _ (And c c' cs, s) = pure . SumF $ fmap (claim . (, s)) (c :: c' :: cs)
   where claim = pure . Left
-
+-- Or
 ϵ _ _ _ (Or c c' cs, s) = pure . MaxF $ fmap (claim . (, s)) (c :: c' :: cs)
   where claim = pure . Left
-
+-- When, the acquisition time of the inner contract is known and not in the future
 ϵ spot t ccy (When pred c, s) | beforeOrAtToday t τ == Some True = ϵ spot t ccy (c, τ)
   where τ = extend pred s
--- ^ the acquisition time of the inner contract is known and not in the future
-
+-- When, the acquisition time of the inner contract is either unknown or known but in the future
 ϵ _ t ccy (When pred c, s) = pure $ MulF (ex (disc * claim (c,τ)) τ filtration) $ inv disc
   where τ = extend pred s
         filtration = case s of
@@ -96,16 +101,13 @@ fapf spot ccy t acquisitionTime claim =
         x * y = Free $ MulF x y
         ex e τ f = Free $ E_F e τ f
         inv = Free . InvF
--- ^ the acquisition time of the inner contract is either unknown or known but in the future
-
+-- Cond, the acquisition time of the inner contract is known and not in the future
 ϵ spot t ccy (Cond pred c1 c2, s) | beforeOrAtToday t s == Some True = do
   let
     Some obsTime = resolve s
   predicate <- compare spot pred obsTime
   if predicate then ϵ spot t ccy (c1, s) else ϵ spot t ccy (c2, s)
--- ^ the acquisition time of the `Cond` node is known and not in the future
--- potentially we could replace this by a 1 * if we want to avoid the recursive call inside the RV-coalgebra
-
+-- Cond, the acquisition time is either unknown or known but in the future
 ϵ spot t ccy (Cond pred c1 c2, s) =
   let
     v1 = ind pred * claim (c1,s)
@@ -117,25 +119,12 @@ fapf spot ccy t acquisitionTime claim =
         x * y = Free $ MulF x y
         ind = Free . I_F
         one = Free $ ConstF munit
--- ^ the acquisition time of the inner contract is either unknown or known but in the future
--- Value is ind(p) * c1 + (1 - ind(p)) * c2 where p is the boolean process implied by the inequality
+-- Until
+ϵ _ _ _ (Until _ _, _) = abort "Valuation semantics for `Until` is not supported yet."
+-- Anytime
+ϵ _ _ _ (Anytime _ _, _) = abort "Valuation semantics for `Anytime` is not supported yet."
 
--- DONE:
--- zero
--- one
--- give
--- scale
--- when
--- and
--- cond
-
--- MISSING :
--- or
--- anytime
--- until
-ϵ _ _ _ _ = abort "Unsupported primitive"
-
--- TODO how do we calculate value given initial acquisition time? We need to discount as of today so probably need to introduce an extra discount term disc s / disc t initially ...
+-- TODO : handle `Never` acquisition time which could originate from using `TimeLte`. We probably need to use resolve at every step.
 
 -- | HIDE
 -- Carrier of the CV-coalgebra ϵ ||| υ

--- a/test/daml/Test/Pricing.daml
+++ b/test/daml/Test/Pricing.daml
@@ -3,108 +3,108 @@
 
 module Test.Pricing where
 
-import ContingentClaims.Claim
-import ContingentClaims.Financial (european, american)
-import ContingentClaims.Observation qualified as O
-import ContingentClaims.MathML qualified as MathML
-import ContingentClaims.Math.Stochastic (fapf, {- simplify, -} riskless, gbm, Expr(..), unitIdentity, IsIdentifier(..))
-import Daml.Control.Recursion (cata)
+-- import ContingentClaims.Claim
+-- import ContingentClaims.Financial (european, american)
+-- import ContingentClaims.Observation qualified as O
+-- import ContingentClaims.MathML qualified as MathML
+-- import ContingentClaims.Math.Stochastic (fapf, {- simplify, -} riskless, gbm, Expr(..), IsIdentifier(..))
+-- import Daml.Control.Recursion (cata)
 
-import Daml.Script
-import DA.Assert
-import Prelude hiding (max)
+-- import Daml.Script
+-- import DA.Assert
+-- import Prelude hiding (max)
 
-data Instrument = USD | EUR | AMZN | APPL deriving (Show, Eq)
+-- data Instrument = USD | EUR | AMZN | APPL deriving (Show, Eq)
 
-data Observable = Spot_AMZN | Spot_APPL deriving (Show, Eq)
+-- data Observable = Spot_AMZN | Spot_APPL deriving (Show, Eq)
 
-spot : Instrument -> Observable
-spot AMZN = Spot_AMZN
-spot APPL = Spot_APPL
-spot other = error $ "disc: " <> show other
+-- spot : Instrument -> Observable
+-- spot AMZN = Spot_AMZN
+-- spot APPL = Spot_APPL
+-- spot other = error $ "disc: " <> show other
 
-call : Instrument -> Decimal -> Instrument -> Claim t Decimal Instrument Observable
-call s k a = scale (O.observe (spot s) - O.pure k) $ one a
+-- call : Instrument -> Decimal -> Instrument -> Claim t Decimal Instrument Observable
+-- call s k a = scale (O.observe (spot s) - O.pure k) $ one a
 
-margrabe s1 s2 a = scale (O.observe (spot s1) - O.observe (spot s2)) $ one a
+-- margrabe s1 s2 a = scale (O.observe (spot s1) - O.observe (spot s2)) $ one a
 
-disc USD = riskless "r_USD"
-disc EUR = riskless "r_EUR"
-disc other = error $ "disc: " <> show other
+-- disc USD = riskless "r_USD"
+-- disc EUR = riskless "r_EUR"
+-- disc other = error $ "disc: " <> show other
 
-val Spot_AMZN = gbm "μ_AMZN" "σ_AMZN"
-val Spot_APPL = gbm "μ_APPL" "σ_APPL"
+-- val Spot_AMZN = gbm "μ_AMZN" "σ_AMZN"
+-- val Spot_APPL = gbm "μ_APPL" "σ_APPL"
 
-exch a a' = error $ "exch: " <> show a <> "/" <> show a'
+-- exch a a' = error $ "exch: " <> show a <> "/" <> show a'
 
-t = "t"  -- today
-t' = "T" -- maturity
+-- t = "t"  -- today
+-- t' = "T" -- maturity
 
-instance IsIdentifier Text where
-  localVar i = "τ_" <> show i
+-- instance IsIdentifier Text where
+--   localVar i = "τ_" <> show i
 
-instance Additive (Expr t) where
-  x + y = Sum [x, y]
-  negate = Neg
-  aunit = Const 0.0
+-- instance Additive (Expr t) where
+--   x + y = Sum [x, y]
+--   negate = Neg
+--   aunit = Const 0.0
 
-instance Multiplicative (Expr t) where
-  (*) = curry Mul
-  x ^ y = curry Pow x $ Const (intToDecimal y)
-  munit = Const 1.0
+-- instance Multiplicative (Expr t) where
+--   (*) = curry Mul
+--   x ^ y = curry Pow x $ Const (intToDecimal y)
+--   munit = Const 1.0
 
-instance Divisible (Expr t) where
-  x / y = curry Mul x . curry Pow y . Neg . Const $ 1.0
+-- instance Divisible (Expr t) where
+--   x / y = curry Mul x . curry Pow y . Neg . Const $ 1.0
 
-instance Number (Expr t) where
+-- instance Number (Expr t) where
 
-max x y = I (x, y) * x + I (y, x) * y
+-- max x y = I (x, y) * x + I (y, x) * y
 
--- This is needed because scale x (one USD) = x * 1.0. It would make writing
--- the expressions by hand tedious
-multIdentity = cata unitIdentity
+-- -- This is needed because scale x (one USD) = x * 1.0. It would make writing
+-- -- the expressions by hand tedious
+-- multIdentity = cata unitIdentity
 
--- Helper to compare the output in XML format (paste this into a browser)
-print f e = do debug $ "Formula:" <> prnt f
-               debug $ "Expected:" <> prnt e
-  where prnt = show . MathML.presentation {- . simplify -}
+-- -- Helper to compare the output in XML format (paste this into a browser)
+-- print f e = do debug $ "Formula:" <> prnt f
+--                debug $ "Expected:" <> prnt e
+--   where prnt = show . MathML.presentation {- . simplify -}
 
-valueCall = script do
-  let formula = fapf USD disc exch val t $ european t' (call AMZN 3300.0 USD)
-      s = Proc "Spot_AMZN" (val Spot_AMZN)
-      k = Const 3300.0
-      usd = Proc "USD" (disc USD)
-      expect = usd t * E (max (s t' - k) aunit / usd t') t
-  print formula expect
-  multIdentity formula === expect
-
-valueMargrabe = script do
-  let formula = fapf USD disc exch val t $ european t' (margrabe AMZN APPL USD)
-      s = Proc "Spot_AMZN" (val Spot_AMZN)
-      s' = Proc "Spot_APPL" (val Spot_APPL)
-      usd = Proc "USD" (disc USD)
-      expect = usd t * E (max (s t' - s' t') aunit / usd t') t
-  print formula expect
-  multIdentity formula === expect
-
--- valueAmerican = script do
---   let formula = fapf USD disc exch t $ american t t' (call APPL 142.50 USD)
---       s = Proc "APPL" (exch APPL USD)
---       k = Const 142.50
+-- valueCall = script do
+--   let formula = fapf USD disc exch val t $ european t' (call AMZN 3300.0 USD)
+--       s = Proc "Spot_AMZN" (val Spot_AMZN)
+--       k = Const 3300.0
 --       usd = Proc "USD" (disc USD)
---       τ = "τ_0"
---       expect = Sup t τ (usd t * E (max (s τ - k) aunit * I (Ident τ, Ident t') / usd τ ) t)
+--       expect = usd t * E (max (s t' - k) aunit / usd t') t
 --   print formula expect
 --   multIdentity formula === expect
 
--- Check to see that the subscript numbering works
-testMonadicBind = script do
-  let τ₀ = "τ_0"
-      τ₁ = "τ_1"
-      t₀ = "t_0"
-      t₁ = "t_1"
-      usd = Proc "USD" (disc USD)
-      formula = fapf USD disc exch val t $ anytime (TimeGte t₀) (anytime (TimeGte t₁) (one USD))
-      expect = Sup t₀ τ₀ (usd t * E (Sup t₁ τ₁ (usd τ₀ * E (munit / usd τ₁) τ₀) / usd τ₀) t) -- note the innermost 1/USD_τ₁ is mult identity
-  print formula expect
-  multIdentity formula === multIdentity expect
+-- valueMargrabe = script do
+--   let formula = fapf USD disc exch val t $ european t' (margrabe AMZN APPL USD)
+--       s = Proc "Spot_AMZN" (val Spot_AMZN)
+--       s' = Proc "Spot_APPL" (val Spot_APPL)
+--       usd = Proc "USD" (disc USD)
+--       expect = usd t * E (max (s t' - s' t') aunit / usd t') t
+--   print formula expect
+--   multIdentity formula === expect
+
+-- -- valueAmerican = script do
+-- --   let formula = fapf USD disc exch t $ american t t' (call APPL 142.50 USD)
+-- --       s = Proc "APPL" (exch APPL USD)
+-- --       k = Const 142.50
+-- --       usd = Proc "USD" (disc USD)
+-- --       τ = "τ_0"
+-- --       expect = Sup t τ (usd t * E (max (s τ - k) aunit * I (Ident τ, Ident t') / usd τ ) t)
+-- --   print formula expect
+-- --   multIdentity formula === expect
+
+-- -- Check to see that the subscript numbering works
+-- testMonadicBind = script do
+--   let τ₀ = "τ_0"
+--       τ₁ = "τ_1"
+--       t₀ = "t_0"
+--       t₁ = "t_1"
+--       usd = Proc "USD" (disc USD)
+--       formula = fapf USD disc exch val t $ anytime (TimeGte t₀) (anytime (TimeGte t₁) (one USD))
+--       expect = Sup t₀ τ₀ (usd t * E (Sup t₁ τ₁ (usd τ₀ * E (munit / usd τ₁) τ₀) / usd τ₀) t) -- note the innermost 1/USD_τ₁ is mult identity
+--   print formula expect
+--   multIdentity formula === multIdentity expect

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -15,11 +15,15 @@ import DA.Date
 import DA.Tuple (thd3)
 import Prelude hiding (or, max, (<=))
 
-type C = Claim Date Decimal Text Text
+data Instrument = USD | A | B | C deriving (Eq, Show)
+
+data Observable = Spot_AMZN deriving (Eq, Show)
+
+type C = Claim Date Decimal Instrument Observable
+type O = O.Observation Date Decimal Observable
 
 -- | Assets
-[a,b,c] = ["a","b","c"]
-ccy = "USD"
+[ccy, a, b, c] = [USD, A, B, C]
 
 -- | Dates
 t0 = date 1970 Jan 1
@@ -27,10 +31,11 @@ t1 = succ t0
 t2 = succ t1
 
 -- | Observations
-two : O.Observation Date Decimal Text = O.pure 2.0
+two : O = O.pure 2.0
+spotAmzn = O.observe Spot_AMZN
 
 -- | Functions performing observations
-observe25: Text -> Date -> Script Decimal = const . const . pure $ 25.0
+observe25: Observable -> Date -> Script Decimal = const . const . pure $ 25.0
 observeDayOfMonth _ d = pure . intToDecimal . thd3 . toGregorian $ d
 
 -- | Inequalities
@@ -41,12 +46,6 @@ atT1 = TimeGte t1
 -- Helper expressions
 disc = Proc $ Disc ccy
 exch = Proc $ Exch a ccy
-
--- max x y = I (x, y) * x + I (y, x) * y
-
--- This is needed because scale x (one USD) = x * 1.0. It would make writing
--- the expressions by hand tedious
--- multIdentity = cata unitIdentity
 
 -- | Valuation of `One` and `Zero` nodes.
 testValuationBasic : Script()
@@ -95,7 +94,7 @@ testValuationWhen = do
 
   -- 3. When (o1 <= o2) ...
   let
-    pred = Lte (O.Const 100.0, O.observe "spot") -- spot greater or equal than 100.0
+    pred = O.Const 100.0 <= spotAmzn -- spot greater or equal than 100.0
     c2 = when pred $ one a
 
     f = Time t0 -- filtration
@@ -111,12 +110,12 @@ testValuationWhen = do
 testValuationScale : Script()
 testValuationScale = do
   let
-    observable  = O.Const 5.0 + O.observe "spot"
+    observable  = O.Const 5.0 + spotAmzn
     claim : C = when atT1 $ scale observable $ one a
 
     f = Time t0 -- filtration
     τ = Time t1 -- stopping rule
-    obsProcess = Const 5.0 + Proc (Observable "spot")
+    obsProcess = Const 5.0 + Proc (Observable Spot_AMZN)
     expect = E (disc * (obsProcess * exch) ) τ f / disc
 
   -- At `t0` the stopping rule is not verified
@@ -132,9 +131,9 @@ testValuationScale = do
 testValuationCond : Script()
 testValuationCond = do
   let
-    p1 = O.Const 5.0 <= O.observe "spot"
+    p1 = O.Const 5.0 <= spotAmzn
     c1 : C = when atT1 $ cond p1 (one a) zero
-    p2 = O.observe "spot" <= O.Const 5.0
+    p2 = spotAmzn <= O.Const 5.0
     c2 : C = when atT1 $ cond p2 (one a) zero
 
     f = Time t0 -- filtration
@@ -154,6 +153,13 @@ testValuationCond = do
 
   pure ()
 
-  -- TODO : write helper function to collect observables (catamorphism)
-
-  -- TODO : write helper function to collect relevant fixing dates (for the purpose of MC simulation)
+-- valueCall = script do
+--   let
+--     c =
+--     formula = fapf observe25 ccy val t $ european t' (call AMZN 3300.0 USD)
+--       s = Proc "Spot_AMZN" (val Spot_AMZN)
+--       k = Const 3300.0
+--       usd = Proc "USD" (disc USD)
+--       expect = usd t * E (max (s t' - k) aunit / usd t') t
+--   print formula expect
+--   multIdentity formula === expect

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -1,0 +1,135 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Test.Pricing2 where
+
+import ContingentClaims.Claim
+import ContingentClaims.Observation qualified as O
+import ContingentClaims.Math.AcquisitionTime
+import ContingentClaims.Math.Expression
+import ContingentClaims.Math.Stochastic2
+
+import Daml.Script
+import DA.Assert
+import DA.Date
+import DA.Tuple (thd3)
+import Prelude hiding (max)
+
+type C = Claim Date Decimal Text
+
+-- | Assets
+[a,b,c] = ["a","b","c"]
+ccy = "USD"
+
+-- | Dates
+today = date 1970 Jan 1
+tomorrow = succ today
+afterTomorrow = succ tomorrow
+
+-- | Observations 
+two : O.Observation Date Decimal Text = O.pure 2.0
+
+-- | Functions performing observations
+observe25: Text -> Date -> Script Decimal = const . const . pure $ 25.0
+observeDayOfMonth _ d = pure . intToDecimal . thd3 . toGregorian $ d
+
+-- | Inequalities
+false = TimeGte $ date 3000 Jan 1
+true = TimeGte $ date 1970 Jan 1
+atTomorrow = TimeGte tomorrow
+
+-- Helper expressions
+disc = Proc $ Disc ccy
+exch = Proc $ Exch a ccy
+
+-- max x y = I (x, y) * x + I (y, x) * y
+
+-- This is needed because scale x (one USD) = x * 1.0. It would make writing
+-- the expressions by hand tedious
+-- multIdentity = cata unitIdentity
+
+testValuationBasic : Script()
+testValuationBasic = do
+
+  value <- fapf observe25 ccy today (one a)
+  value === Proc (Exch a ccy)
+
+  value <- fapf observe25 ccy today (one ccy)
+  value === Const 1.0
+
+  value <- fapf observe25 ccy today (one ccy)
+  value === Const 1.0
+
+  value <- fapf observe25 ccy today zero
+  value === Const 0.0
+
+  pure ()
+  
+testValuationWhen : Script()
+testValuationWhen = do
+
+  -- `today` the stopping rule defined by `When` is not verified, so we take expectation of discounted payoff
+  let f = Time today 
+      -- ^ filtration (i.e. available information)
+      τ = Time tomorrow
+      -- ^ stopping time defined by the `When` node
+
+  value <- fapf observe25 ccy today (when atTomorrow $ one a)
+  value === E (disc * exch) τ f / disc
+
+  -- `tomorrow` the stopping rule is verified
+  value <- fapf observe25 ccy tomorrow (when atTomorrow $ one a)
+  value === exch
+
+testValuationScale : Script()
+testValuationScale = do
+
+  -- we define a stochastic observable, as well as the corresponding process
+  let observable  = O.Const 5.0 + O.observe "spot" 
+      obsProcess = Const 5.0 + Proc (Observable "spot")
+
+      claim : C = when atTomorrow $ scale observable $ one a
+
+      f = Time today -- filtration
+      τ = Time tomorrow -- stopping rule
+
+  -- `today` the stopping rule is not verified
+  value <- fapf observe25 ccy today claim
+  value === E (disc * (obsProcess * exch) ) τ f / disc
+
+  -- `tomorrow` the stopping rule is verified
+  value <- fapf observe25 ccy tomorrow claim
+  value === (Const 5.0 + Const 25.0) * exch
+
+  -- TODO write test with stochastic stopping time
+
+  pure ()
+
+-- | Claim with stochastic stopping rule
+testValuationKnockOut : Script()
+testValuationKnockOut = do
+
+  -- we define a stochastic observable
+  let spotGreaterThan100 = Lte (O.Const 100.0, O.observe "spot")
+
+      claim : C = when spotGreaterThan100 $ one a
+
+      f = Time today -- filtration
+      τ = AtInequality [spotGreaterThan100] -- stopping rule
+
+  value <- fapf observe25 ccy today claim
+  value === E (disc * exch) τ f / disc
+
+  -- we do not consider the case when the stopping rule is verified before or at t,
+  -- given that the valuation focuses on claims that are "up-to-date" with respect to lifecycle
+  -- and the lifecycle function replaces verified stochastic stopping rule with deterministic ones
+
+  -- TODO : we should define a mapping from inequality to the corresponding stochastic process (same as for observables) as these need to be simulated
+
+  -- TODO : write helper function to collect observables (catamorphism)
+
+  -- TODO : write helper function to collect relevant fixing dates (for the purpose of MC simulation)
+
+  -- TODO : check if we can call pure Haskell functions from Java bindings (because if we can't, there is no point writing helper functions that are used outside of the Daml layer)
+
+  pure ()

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -13,7 +13,7 @@ import Daml.Script
 import DA.Assert
 import DA.Date
 import DA.Tuple (thd3)
-import Prelude hiding (max, (<=))
+import Prelude hiding (or, max, (<=))
 
 type C = Claim Date Decimal Text Text
 
@@ -53,13 +53,22 @@ testValuationBasic : Script()
 testValuationBasic = do
 
   value <- fapf observe25 ccy t0 t0 (one a)
-  value === Proc (Exch a ccy)
+  value === exch
 
   value <- fapf observe25 ccy t0 t0 (one ccy)
   value === Const 1.0
 
   value <- fapf observe25 ccy t0 t0 zero
   value === Const 0.0
+
+  value <- fapf observe25 ccy t0 t0 $ give (one a)
+  value === -exch
+
+  value <- fapf observe25 ccy t0 t0 $ one a <> one b <> one c
+  value === Sum [exch, Proc (Exch b ccy), Proc (Exch c ccy)]
+
+  value <- fapf observe25 ccy t0 t0 $ one a `or` one b
+  value === Max [exch, Proc (Exch b ccy)]
 
   pure ()
 

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -15,7 +15,7 @@ import DA.Date
 import DA.Tuple (thd3)
 import Prelude hiding (max)
 
-type C = Claim Date Decimal Text
+type C = Claim Date Decimal Text Text
 
 -- | Assets
 [a,b,c] = ["a","b","c"]
@@ -26,7 +26,7 @@ today = date 1970 Jan 1
 tomorrow = succ today
 afterTomorrow = succ tomorrow
 
--- | Observations 
+-- | Observations
 two : O.Observation Date Decimal Text = O.pure 2.0
 
 -- | Functions performing observations
@@ -51,41 +51,41 @@ exch = Proc $ Exch a ccy
 testValuationBasic : Script()
 testValuationBasic = do
 
-  value <- fapf observe25 ccy today (one a)
+  value <- fapf observe25 ccy today today (one a)
   value === Proc (Exch a ccy)
 
-  value <- fapf observe25 ccy today (one ccy)
+  value <- fapf observe25 ccy today today (one ccy)
   value === Const 1.0
 
-  value <- fapf observe25 ccy today (one ccy)
+  value <- fapf observe25 ccy today today (one ccy)
   value === Const 1.0
 
-  value <- fapf observe25 ccy today zero
+  value <- fapf observe25 ccy today today zero
   value === Const 0.0
 
   pure ()
-  
+
 testValuationWhen : Script()
 testValuationWhen = do
 
   -- `today` the stopping rule defined by `When` is not verified, so we take expectation of discounted payoff
-  let f = Time today 
+  let f = Time today
       -- ^ filtration (i.e. available information)
       τ = Time tomorrow
       -- ^ stopping time defined by the `When` node
 
-  value <- fapf observe25 ccy today (when atTomorrow $ one a)
+  value <- fapf observe25 ccy today today (when atTomorrow $ one a)
   value === E (disc * exch) τ f / disc
 
   -- `tomorrow` the stopping rule is verified
-  value <- fapf observe25 ccy tomorrow (when atTomorrow $ one a)
+  value <- fapf observe25 ccy tomorrow today (when atTomorrow $ one a)
   value === exch
 
 testValuationScale : Script()
 testValuationScale = do
 
   -- we define a stochastic observable, as well as the corresponding process
-  let observable  = O.Const 5.0 + O.observe "spot" 
+  let observable  = O.Const 5.0 + O.observe "spot"
       obsProcess = Const 5.0 + Proc (Observable "spot")
 
       claim : C = when atTomorrow $ scale observable $ one a
@@ -94,11 +94,11 @@ testValuationScale = do
       τ = Time tomorrow -- stopping rule
 
   -- `today` the stopping rule is not verified
-  value <- fapf observe25 ccy today claim
+  value <- fapf observe25 ccy today today claim
   value === E (disc * (obsProcess * exch) ) τ f / disc
 
   -- `tomorrow` the stopping rule is verified
-  value <- fapf observe25 ccy tomorrow claim
+  value <- fapf observe25 ccy tomorrow today claim
   value === (Const 5.0 + Const 25.0) * exch
 
   -- TODO write test with stochastic stopping time
@@ -117,7 +117,7 @@ testValuationKnockOut = do
       f = Time today -- filtration
       τ = AtInequality [spotGreaterThan100] -- stopping rule
 
-  value <- fapf observe25 ccy today claim
+  value <- fapf observe25 ccy today today claim
   value === E (disc * exch) τ f / disc
 
   -- we do not consider the case when the stopping rule is verified before or at t,

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -13,7 +13,7 @@ import Daml.Script
 import DA.Assert
 import DA.Date
 import DA.Tuple (thd3)
-import Prelude hiding (max)
+import Prelude hiding (max, (<=))
 
 type C = Claim Date Decimal Text Text
 
@@ -120,7 +120,30 @@ testValuationScale = do
 
   pure ()
 
-  -- TODO : we should define a mapping from inequality to the corresponding stochastic process (same as for observables) as these need to be simulated
+testValuationCond : Script()
+testValuationCond = do
+  let
+    p1 = O.Const 5.0 <= O.observe "spot"
+    c1 : C = when atT1 $ cond p1 (one a) zero
+    p2 = O.observe "spot" <= O.Const 5.0
+    c2 : C = when atT1 $ cond p2 (one a) zero
+
+    f = Time t0 -- filtration
+    τ = Time t1 -- stopping rule
+    expect = E (disc * (I p1 * exch + (Const 1.0 - I p1) * aunit) ) τ f / disc
+
+  -- At `t0` the stopping rule is not verified
+  value <- fapf observe25 ccy t0 t0 c1
+  value === expect
+
+  -- At `t1` the stopping rule is verified
+  value <- fapf observe25 ccy t1 t0 c1
+  value === exch
+
+  value <- fapf observe25 ccy t1 t0 c2
+  value === aunit
+
+  pure ()
 
   -- TODO : write helper function to collect observables (catamorphism)
 

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -22,9 +22,9 @@ type C = Claim Date Decimal Text Text
 ccy = "USD"
 
 -- | Dates
-today = date 1970 Jan 1
-tomorrow = succ today
-afterTomorrow = succ tomorrow
+t0 = date 1970 Jan 1
+t1 = succ t0
+t2 = succ t1
 
 -- | Observations
 two : O.Observation Date Decimal Text = O.pure 2.0
@@ -36,7 +36,7 @@ observeDayOfMonth _ d = pure . intToDecimal . thd3 . toGregorian $ d
 -- | Inequalities
 false = TimeGte $ date 3000 Jan 1
 true = TimeGte $ date 1970 Jan 1
-atTomorrow = TimeGte tomorrow
+atT1 = TimeGte t1
 
 -- Helper expressions
 disc = Proc $ Disc ccy
@@ -48,88 +48,80 @@ exch = Proc $ Exch a ccy
 -- the expressions by hand tedious
 -- multIdentity = cata unitIdentity
 
+-- | Valuation of `One` and `Zero` nodes.
 testValuationBasic : Script()
 testValuationBasic = do
 
-  value <- fapf observe25 ccy today today (one a)
+  value <- fapf observe25 ccy t0 t0 (one a)
   value === Proc (Exch a ccy)
 
-  value <- fapf observe25 ccy today today (one ccy)
+  value <- fapf observe25 ccy t0 t0 (one ccy)
   value === Const 1.0
 
-  value <- fapf observe25 ccy today today (one ccy)
-  value === Const 1.0
-
-  value <- fapf observe25 ccy today today zero
+  value <- fapf observe25 ccy t0 t0 zero
   value === Const 0.0
 
   pure ()
 
+-- | Valuation of `When` nodes.
 testValuationWhen : Script()
 testValuationWhen = do
+  -- 1. When (TimeGte t) ...
+  let
+    c1 = when atT1 $ one a
+    expect = E (disc * exch) τ f / disc
+        where
+          f = Time t0 -- filtration (i.e. available information)
+          τ = Time t1 -- stopping time defined by the `When` node
 
-  -- `today` the stopping rule defined by `When` is not verified, so we take expectation of discounted payoff
-  let f = Time today
-      -- ^ filtration (i.e. available information)
-      τ = Time tomorrow
-      -- ^ stopping time defined by the `When` node
+  -- At `t0` the stopping rule defined by `When` is not verified, so we take expectation of discounted payoff
+  value <- fapf observe25 ccy t0 t0 c1
+  value === expect
 
-  value <- fapf observe25 ccy today today (when atTomorrow $ one a)
+  -- At `t1` the stopping rule is verified, so we get rid of the `When` node
+  value <- fapf observe25 ccy t1 t0 c1
+  value === exch
+
+  -- 1. When (TimeLte t) ...
+
+  -- 3. When (o1 <= o2) ...
+  let
+    pred = Lte (O.Const 100.0, O.observe "spot") -- spot greater or equal than 100.0
+    c2 = when pred $ one a
+
+    f = Time t0 -- filtration
+    τ = AtInequality [TimeGte t0, pred] -- stopping rule
+
+  value <- fapf observe25 ccy t0 t0 c2
   value === E (disc * exch) τ f / disc
 
-  -- `tomorrow` the stopping rule is verified
-  value <- fapf observe25 ccy tomorrow today (when atTomorrow $ one a)
-  value === exch
+  -- We do not consider the case when the stopping rule is verified before or at t,
+  -- given that the valuation focuses on claims that are "up-to-date" with respect to lifecycle events
+  -- and the lifecycle function replaces verified stochastic stopping rule with deterministic ones
 
 testValuationScale : Script()
 testValuationScale = do
+  let
+    observable  = O.Const 5.0 + O.observe "spot"
+    claim : C = when atT1 $ scale observable $ one a
 
-  -- we define a stochastic observable, as well as the corresponding process
-  let observable  = O.Const 5.0 + O.observe "spot"
-      obsProcess = Const 5.0 + Proc (Observable "spot")
+    f = Time t0 -- filtration
+    τ = Time t1 -- stopping rule
+    obsProcess = Const 5.0 + Proc (Observable "spot")
+    expect = E (disc * (obsProcess * exch) ) τ f / disc
 
-      claim : C = when atTomorrow $ scale observable $ one a
+  -- At `t0` the stopping rule is not verified
+  value <- fapf observe25 ccy t0 t0 claim
+  value === expect
 
-      f = Time today -- filtration
-      τ = Time tomorrow -- stopping rule
-
-  -- `today` the stopping rule is not verified
-  value <- fapf observe25 ccy today today claim
-  value === E (disc * (obsProcess * exch) ) τ f / disc
-
-  -- `tomorrow` the stopping rule is verified
-  value <- fapf observe25 ccy tomorrow today claim
+  -- At `t1` the stopping rule is verified
+  value <- fapf observe25 ccy t1 t0 claim
   value === (Const 5.0 + Const 25.0) * exch
 
-  -- TODO write test with stochastic stopping time
-
   pure ()
-
--- | Claim with stochastic stopping rule
-testValuationKnockOut : Script()
-testValuationKnockOut = do
-
-  -- we define a stochastic observable
-  let spotGreaterThan100 = Lte (O.Const 100.0, O.observe "spot")
-
-      claim : C = when spotGreaterThan100 $ one a
-
-      f = Time today -- filtration
-      τ = AtInequality [spotGreaterThan100] -- stopping rule
-
-  value <- fapf observe25 ccy today today claim
-  value === E (disc * exch) τ f / disc
-
-  -- we do not consider the case when the stopping rule is verified before or at t,
-  -- given that the valuation focuses on claims that are "up-to-date" with respect to lifecycle
-  -- and the lifecycle function replaces verified stochastic stopping rule with deterministic ones
 
   -- TODO : we should define a mapping from inequality to the corresponding stochastic process (same as for observables) as these need to be simulated
 
   -- TODO : write helper function to collect observables (catamorphism)
 
   -- TODO : write helper function to collect relevant fixing dates (for the purpose of MC simulation)
-
-  -- TODO : check if we can call pure Haskell functions from Java bindings (because if we can't, there is no point writing helper functions that are used outside of the Daml layer)
-
-  pure ()

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -4,6 +4,7 @@
 module Test.Pricing2 where
 
 import ContingentClaims.Claim
+import ContingentClaims.Financial (european)
 import ContingentClaims.Observation qualified as O
 import ContingentClaims.Math.AcquisitionTime
 import ContingentClaims.Math.Expression
@@ -15,30 +16,35 @@ import DA.Date
 import DA.Tuple (thd3)
 import Prelude hiding (or, max, (<=))
 
+-- | Assets.
 data Instrument = USD | A | B | C deriving (Eq, Show)
 
+-- | Observables.
 data Observable = Spot_AMZN deriving (Eq, Show)
 
+-- | The claim type used for the tests.
 type C = Claim Date Decimal Instrument Observable
+
+-- | The observation type used for the tests.
 type O = O.Observation Date Decimal Observable
 
--- | Assets
+-- Assets
 [ccy, a, b, c] = [USD, A, B, C]
 
--- | Dates
+-- Dates
 t0 = date 1970 Jan 1
 t1 = succ t0
 t2 = succ t1
 
--- | Observations
+-- Observations
 two : O = O.pure 2.0
 spotAmzn = O.observe Spot_AMZN
 
--- | Functions performing observations
+-- Functions performing observations
 observe25: Observable -> Date -> Script Decimal = const . const . pure $ 25.0
 observeDayOfMonth _ d = pure . intToDecimal . thd3 . toGregorian $ d
 
--- | Inequalities
+-- Inequalities
 false = TimeGte $ date 3000 Jan 1
 true = TimeGte $ date 1970 Jan 1
 atT1 = TimeGte t1
@@ -47,7 +53,7 @@ atT1 = TimeGte t1
 disc = Proc $ Disc ccy
 exch = Proc $ Exch a ccy
 
--- | Valuation of `One` and `Zero` nodes.
+-- | Valuation of `One`, `Zero`, `Give`, `And`, `Or` nodes.
 testValuationBasic : Script()
 testValuationBasic = do
 
@@ -107,6 +113,7 @@ testValuationWhen = do
   -- given that the valuation focuses on claims that are "up-to-date" with respect to lifecycle events
   -- and the lifecycle function replaces verified stochastic stopping rule with deterministic ones
 
+-- | Valuation of `Scale` nodes.
 testValuationScale : Script()
 testValuationScale = do
   let
@@ -128,6 +135,7 @@ testValuationScale = do
 
   pure ()
 
+-- | Valuation of `Cond` nodes.
 testValuationCond : Script()
 testValuationCond = do
   let
@@ -153,13 +161,27 @@ testValuationCond = do
 
   pure ()
 
--- valueCall = script do
---   let
---     c =
---     formula = fapf observe25 ccy val t $ european t' (call AMZN 3300.0 USD)
---       s = Proc "Spot_AMZN" (val Spot_AMZN)
---       k = Const 3300.0
---       usd = Proc "USD" (disc USD)
---       expect = usd t * E (max (s t' - k) aunit / usd t') t
---   print formula expect
---   multIdentity formula === expect
+valueCall = script do
+  let
+    k = O.pure 100.0 -- strike price
+    c : C = european t1 $ scale (spotAmzn - k) $ one USD
+    f = Time t0 -- filtration
+    τ = Time t1 -- stopping rule
+    obsProcess = Proc (Observable Spot_AMZN) - Const 100.0
+    expect = E (disc * Max [ obsProcess * Const 1.0 , aunit ] ) τ f / disc
+
+  -- before expiry
+  value <- fapf observe25 ccy t0 t0 c
+  value === expect
+
+  let
+    obsProcess = Const 25.0 - Const 100.0
+    expect = Max [ obsProcess * Const 1.0 , aunit ]
+
+  -- at expiry (but before exercise)
+  value <- fapf observe25 ccy t1 t0 c
+  value === expect
+
+  pure ()
+
+-- TODO simplify Mul Const 1.0

--- a/test/daml/Test/Pricing2.daml
+++ b/test/daml/Test/Pricing2.daml
@@ -80,7 +80,7 @@ testValuationBasic = do
 -- | Valuation of `When` nodes.
 testValuationWhen : Script()
 testValuationWhen = do
-  -- 1. When (TimeGte t) ...
+  -- 1. When (TimeGte t) c
   let
     c1 = when atT1 $ one a
     expect = E (disc * exch) τ f / disc
@@ -96,9 +96,7 @@ testValuationWhen = do
   value <- fapf observe25 ccy t1 t0 c1
   value === exch
 
-  -- 1. When (TimeLte t) ...
-
-  -- 3. When (o1 <= o2) ...
+  -- 2. When (o1 <= o2) c
   let
     pred = O.Const 100.0 <= spotAmzn -- spot greater or equal than 100.0
     c2 = when pred $ one a
@@ -112,6 +110,18 @@ testValuationWhen = do
   -- We do not consider the case when the stopping rule is verified before or at t,
   -- given that the valuation focuses on claims that are "up-to-date" with respect to lifecycle events
   -- and the lifecycle function replaces verified stochastic stopping rule with deterministic ones
+
+  -- 3. When (TimeLte t) c
+  let
+    c3 = when (upTo t0) $ one a
+
+  -- Contract is acquired at `t0`, predicate is verified immediately
+  value <- fapf observe25 ccy t0 t0 c3
+  value === exch
+
+  -- Contract is acquired at `t1`, predicate is never verified
+  value <- fapf observe25 ccy t1 t1 c3
+  value === aunit
 
 -- | Valuation of `Scale` nodes.
 testValuationScale : Script()


### PR DESCRIPTION
This PR introduces a revisited fundamental asset pricing formula.

The existing one did the following:
- map a claim to an expression representing a stochastic process
- make a model assumption, using geometric brownian motion as an elementary process
- serialise the resulting formula to text

The revisited FAPF does only the first step: map a claim to a stochastic process representing its value at time `t`. The process primitives that are used are the ones outlined in the PJ paper: `exch`, `disc`, `observable` (in the future also `snell` and `absorb`.

Moreover, we now handle the propagation of acquisition time, such that
- `scale` nodes that are evaluated before `today` are replaced with their numerical value
- `scale` nodes that are unknown are mapped to the corresponding stoch. process

There are still a couple of things to iron out, specifically
- implementation of `snell` and `absorb` primitive processes to handle `anytime` and `until` nodes (I think we can come to a better expression than what there is in the paper)
- simplification functions

I would like to hear your feedback on this and also discuss whether we need support for printing out the formula in e.g. `MathML` like it's currently done for the existing `fapf`.

The tests can give you an idea of the output which is currently generated.
 